### PR TITLE
fix: filter value types

### DIFF
--- a/src/views/MedicalInstitutionView.vue
+++ b/src/views/MedicalInstitutionView.vue
@@ -145,7 +145,7 @@ import { onMounted, shallowRef } from 'vue'
 import router from '@/router/index'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, MedicalInstitutionReportsURL, MedicalInstitutionSummaryURL } from '@/router/data'
-import { CausalRelationshipFunc, DateFilterFunc, NumberFilterFunc, StringArrayStrictFilterFunc, StringFilterFunc } from '@/tools/FilterFunc'
+import { CausalRelationshipFunc, DateArrayFilterFunc, DateFilterFunc, NumberFilterFunc, StringArrayFilterFunc, StringArrayStrictFilterFunc, StringFilterFunc } from '@/tools/FilterFunc'
 import { SearchTrigger, SearchTriggerFunc } from '@/tools/SearchTriggerFunc'
 import StringArrayRow from '@/components/StringArrayRow.vue'
 import DatesRow from '@/components/DatesRow.vue'
@@ -241,8 +241,8 @@ const daysToOnsetFilterFunc = (value: string): boolean => {
 }
 
 const ptNameFilterVal = shallowRef('')
-const ptNameFilterFunc = (value: string): boolean => {
-  return StringFilterFunc(value, ptNameFilterVal)
+const ptNameFilterFunc = (value: any): boolean => {
+  return StringArrayFilterFunc(value, ptNameFilterVal)
 }
 
 const causualFilterVal = shallowRef('')
@@ -257,8 +257,8 @@ const severityFilterFunc = (value: string): boolean => {
 
 const resultDateFromFilterVal = shallowRef('')
 const resultDateToFilterVal = shallowRef('')
-const resultDateFilterFunc = (value: string): boolean => {
-  return DateFilterFunc(value, resultDateFromFilterVal, resultDateToFilterVal)
+const resultDateFilterFunc = (value: any): boolean => {
+  return DateArrayFilterFunc(value, resultDateFromFilterVal, resultDateToFilterVal)
 }
 
 const resultFilterVal = shallowRef('')


### PR DESCRIPTION
## 問題

`症状`や`転記日`で検索を行った際に、内部で例外が発生してしまい正常に検索結果のフィルタリングが行われていませんでした。

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/cf32fd8e-d821-4738-9800-764ea9430721)

## 修正

文字列用の処理ではなく文字列の配列用の処理に変更するなど、検索対象のパラメータに応じた正しいフィルタリング処理を紐づけて修正しました。