### PR TITLE
新型コロナ以外の各種ワクチンの認定件数を図示する機能を追加

### DIFF
--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -18,3 +18,4 @@ export const DeathSummaryFromReportsURL = DatasetsURL + 'death-summary-from-repo
 export const CertifiedHealthHazardDataURL = DatasetsURL + 'certified-reports.json'
 export const CertifiedSymptomsDataURL = DatasetsURL + 'certified-symptoms.json'
 export const CertifiedSummaryURL = DatasetsURL + 'certified-summary.json'
+export const CertifiedSummaryWithOtherVaccinesURL = DatasetsURL + 'certified-summary-with-other-vaccines.json'

--- a/src/types/CertifiedSummary.ts
+++ b/src/types/CertifiedSummary.ts
@@ -8,3 +8,30 @@ export interface ICertifiedSummary {
 	certified_death_count: number
 	denied_death_count: number
 }
+
+export interface ICertifiedSummaryWithOtherVaccines {
+	meta_data: {
+		covid19_vaccine: IMetaData
+		other_vaccines: IMetaData
+	}
+	chart_data: {
+		headers: string[]
+		data: IChartData[]
+	}
+}
+
+export interface IMetaData {
+	first_date: string
+	last_date: string
+	period: string
+	certified_count: number
+	source_url: string
+}
+
+export interface IChartData {
+	vaccine_name: string
+	medical: number
+	disability_of_children: number
+	disability: number
+	death: number
+}


### PR DESCRIPTION
[こちらのプルリクエスト](https://github.com/vaccinesosjapan/dashboard-datasets/pull/2)で、新型コロナワクチン以外のワクチンに関する認定件数のサマリデータを追加したので、それを表示するグラフの追加などを行った。

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/3e7e0f7b-f0c8-4ed9-9f40-5d538473a0db)
