### PR TITLE
「URLコピー」機能でコピーできるURLを改善

### DIFF
--- a/src/types/QueryParam.ts
+++ b/src/types/QueryParam.ts
@@ -18,10 +18,10 @@ export const CreateUrlWithQueryParams = (queryParamMap: IQueryParam[] | IQueryPa
 	queryParamMap.forEach(item => {
 		if(isNotNullEmpty(item.val)) {
 			if(isFirstQuery){
-			retUrl = retUrl + item.name + '=' + item.val.value
-			isFirstQuery = false
+				retUrl = retUrl + item.name + '=' + encodeURI(item.val.value)
+				isFirstQuery = false
 			} else {
-			retUrl = retUrl + '&' + item.name + '=' + item.val.value
+				retUrl = retUrl + '&' + item.name + '=' + encodeURI(item.val.value)
 			}
 		}
 	})


### PR DESCRIPTION
## 問題点

今までは、「10～20歳の男の方」を検索した場合にURLが`reports-from-medical-institution?adf=10&adt=20&gen=男`というようにコピーされていた。日本語がそのままコピーされるため、X（旧Twitter）などで共有する際にURLとして認識されなかったりした。

## 修正方針

これを、[encodeURI](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)で変換してコピーすることで、`reports-from-medical-institution?adf=10&adt=20&gen=%E7%94%B7`というような文字列でURLコピーができるようになり、TwitterなどでもURLとして認識されるようになる。