### PR TITLE
亡くなった方の症例一覧に関して追加された情報への対応

### DIFF
--- a/src/components/StringArrayRow.vue
+++ b/src/components/StringArrayRow.vue
@@ -1,10 +1,10 @@
 <template>
 	<div v-if="sArray.length == 1">
-		<span v-if="sArray[0].length >= 10">{{ sArray[0].substring(0, 7) }}</span>
+		<span v-if="sArray[0].length > 10">{{ sArray[0].substring(0, 7) + '...' }}</span>
 		<span v-else>{{ sArray[0] }}</span>
     </div>
 	<div v-else-if="sArray.length > 1">
-		<span v-if="sArray[0].length >= 10">{{ sArray[0].substring(0, 7) + '...' }}</span>
+		<span v-if="sArray[0].length > 10">{{ sArray[0].substring(0, 7) + '...' }}</span>
 		<span v-else>{{ sArray[0] + '...' }}</span>
     </div>
 	<div v-else>-</div>

--- a/src/components/StringRow.vue
+++ b/src/components/StringRow.vue
@@ -1,6 +1,6 @@
 <template>
-	<span v-if="content.length >= 10">{{ content.substring(0, 7) + '...' }}</span>
-	<span v-else>{{ content[0] }}</span>
+	<span v-if="content.length > 10">{{ content.substring(0, 7) + '...' }}</span>
+	<span v-else>{{ content }}</span>
 </template>
 
 <script setup lang="ts">

--- a/src/types/ReportedDeath.ts
+++ b/src/types/ReportedDeath.ts
@@ -14,6 +14,8 @@ export interface IReportedDeathIssue {
   vaccinated_times: string
   pre_existing_conditions: string
   PT_names: string[]
+  tests_used_for_determination: string
+  causal_relationship: string
   causal_relationship_by_expert: string
   comments_by_expert: string
   id: string


### PR DESCRIPTION
[こちらのプルリクエスト](https://github.com/vaccinesosjapan/dashboard-datasets/pull/5) にて、報告医が死因の判断のために行った検査や、報告医による因果関係評価の結果がデータセットに追加された。これに伴い、亡くなった方の症例一覧ページの該当データに対して対応を実施した。

また、一覧表示の1行の高さがマチマチにならないように文字列を表示する箇所で文字数制限を行っていたのだが、これの処理が意図したものになっていなかったため、あわせて修正を行った。