### PR TITLE
docs: ページタイトルを実体に沿ったものに変更

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -65,8 +65,8 @@ export const HealthHazardsHomeRoute = {
 export const HealthHazardsSubRoutes = [
   {
     path: '/certified-issues',
-    name: '予防接種健康被害 救済制度 - 認定済み 報告一覧',
-    menu_name: '認定済み 報告一覧',
+    name: '予防接種健康被害 救済制度 - 判定済み 報告一覧',
+    menu_name: '判定済み 報告一覧',
     icon: 'mdi-account-search',
     component: () => import('../views/CertifiedHealthHazardsView.vue')
   },

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -118,10 +118,9 @@
   <v-container>
     <v-card color="green-darken-1" variant="elevated">
       <v-card-title class="card-title">予防接種健康被害 救済制度</v-card-title>
-      <v-card-text class="card-text"
-        >新型コロナワクチンなどの接種により副反応や副作用を被った可能性がある方々が、
-        市町村を通じて申請することで医療費などの給付を受けられる仕組みがあります。認定済みの案件をまとめて、閲覧や
-        検索をしやすくしています。
+      <v-card-text class="card-text">
+        新型コロナワクチンなどの接種により副反応や副作用を被った可能性がある方々が、
+        市町村を通じて申請することで医療費などの給付を受けられる仕組みがあります。判定済みの案件をまとめて、閲覧や検索をしやすくしています。
       </v-card-text>
 
       <v-item-group selected-class="bg-primary">


### PR DESCRIPTION
- ページタイトルを`予防接種健康被害 救済制度 - 判定済み 報告一覧`に変更
- 左側カラムのメニュー名も「認定済み　報告一覧」から「判定済み　報告一覧」に変更

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/73223aee-64c9-4fc6-8ac4-1121c49d2902)

Close #13 