### PR TITLE
fix: fromやtoに指定した日付と同じ日付のデータが表示できていなかったのを修正

### DIFF
--- a/src/tools/FilterFunc.ts
+++ b/src/tools/FilterFunc.ts
@@ -137,7 +137,7 @@ export const DateFilterFunc = (
   // フィルタリング処理が不要な場合はtrueを返すことで、項目を表示させる
   if (nullOrEmptyString(fromFilterVal.value) && nullOrEmptyString(toFilterVal.value)) return true
 
-  const vDate = new Date(value)
+  const vDate = new Date(value.replaceAll('/', '-'))
   // パースに失敗した場合は、日付としての比較ができないため非表示にする
   if (isNaN(vDate.getTime())) return false
 


### PR DESCRIPTION
日付の`from`が検索結果に含まれていなかったのを修正する。

修正前:
![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/5b4e5ea0-6ad2-46d0-9b73-6cc866510507)

修正後:
![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/bf1a03be-94ee-4b93-a31d-077c15847b34)
