### PR TITLE
検索欄の改善を「医療機関からの報告 - 副反応疑い報告」ページにも適用する

### DIFF
--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -9,6 +9,7 @@ const DatasetsURL = import.meta.env.VITE_DATASETS_URL
 //const DatasetsURL = '/_datasets/'
 
 export const MedicalInstitutionReportsURL = DatasetsURL + 'medical-institution-reports.json'
+export const MedicalInstitutionMetadataURL = DatasetsURL + 'medical-institution-metadata.json'
 export const MedicalInstitutionSummaryURL = DatasetsURL + 'medical-institution-summary-from-reports.json'
 
 export const CarditisReportsURL = DatasetsURL + 'carditis-reports.json'

--- a/src/types/MedicalInstitutionMetadata.ts
+++ b/src/types/MedicalInstitutionMetadata.ts
@@ -1,0 +1,8 @@
+export interface IMedicalInstitutionMetadata {
+	gender_list: string[]
+	vaccine_name_list: string[]
+	manufacturer_list: string[]
+	causal_relationship_list: string[]
+	severity_list: string[]
+	gross_results_list: string[]
+}

--- a/src/types/MedicalInstitutionReports.ts
+++ b/src/types/MedicalInstitutionReports.ts
@@ -14,7 +14,7 @@ export interface IMedicalInstitutionReport {
 	causal_relationship: string
 	severity: string
 	gross_result_dates: string
-	gross_results: string
+	gross_results: string[]
 	source: ISourceInfo
 }
 

--- a/src/views/CertifiedHealthHazardsView.vue
+++ b/src/views/CertifiedHealthHazardsView.vue
@@ -248,9 +248,6 @@ const judgedDatesFilterFunc = (value: any): boolean => {
   return judgedDatesFilterValues.value.includes(value)
 }
 
-// 本当はnumber型にしたいのだが、検索入力の関係で空文字やnullも入る
-// それらも考慮した型にすると今度は別の箇所でエラーが・・
-// という事情から、anyを使用
 const ageFromFilterVal = shallowRef<any>('')
 const ageToFilterVal = shallowRef<any>('')
 const ageFilterFunc = (values: any): boolean => {


### PR DESCRIPTION
## 概要

#19 で行ったような検索条件を入力する欄の改善を、「医療機関からの報告 - 副反応疑い報告」ページにも適用する。

## 改善前

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/dd045bf7-ff53-4025-a264-a4e11fbaaa77)

## 改善後

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/e26d9657-31f2-4e32-aec0-db882cfa0ba3)

`製造販売業者`や`ワクチン名`などは、一覧から選択してフィルタリング可能にし、さらに選択項目が多いのでキーワードで選択肢自体を絞り込めるようにした。

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/dbb5d511-8e1c-4660-aab7-f022c87b6572)

また、選択肢からフィルタリング項目を選ぶ際には、複数の項目を選択可能にした。

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/0cc556f4-748d-455f-b604-aa5f05076a07)

cc: @Kanjanokai 