### PR TITLE
製造販売業者に関する説明を表示するボタンを、警告色の警告アイコンと共に追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,5 @@
 {
   "recommendations": [
-    "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]

--- a/src/components/ManufacturerHelpDialog.vue
+++ b/src/components/ManufacturerHelpDialog.vue
@@ -1,0 +1,48 @@
+<template>
+	<v-dialog transition="dialog-bottom-transition" width="auto">
+		<template v-slot:activator="{ props }">
+			<v-btn prepend-icon="mdi-alert-outline" v-bind="props">
+				<template v-slot:prepend>
+					<v-icon color="warning" size="x-large"></v-icon>
+				</template>
+				製造販売業者について...
+			</v-btn>
+		</template>
+
+		<template v-slot:default="{ isActive }">
+		<v-card title="製造販売業者について">
+			<v-card-text>
+				<p>インフルエンザワクチンなどをコロナワクチンと同時に接種する場合があるため、症例一覧にはコロナワクチン以外のワクチン製造販売業者も列挙されています。</p>
+				<p>
+					<span>以下にコロナワクチン以外のワクチン製造販売業者の例を示します（2024/04/30 現在の情報）。</span>
+					<ul class="my-list" v-for="m in exManufacturers" :key="m">
+						<li>{{ m }}</li>
+					</ul>
+				</p>
+			</v-card-text>
+
+			<v-card-actions>
+				<v-spacer></v-spacer>
+				<v-btn
+					text="閉じる"
+					@click="isActive.value = false"
+				>閉じる</v-btn>
+			</v-card-actions>
+		</v-card>
+		</template>
+	</v-dialog>
+</template>
+
+<script setup lang="ts">
+const exManufacturers = ['KMB', 'デンカ', '阪大微研会']
+</script>
+
+<style scoped>
+.wrap-text {
+	white-space: normal;
+}
+
+.my-list {
+	padding: 0 2.5rem;
+}
+</style>

--- a/src/components/SearchableSelectItems.vue
+++ b/src/components/SearchableSelectItems.vue
@@ -23,10 +23,13 @@
 			</v-list-item>
 			<v-list-item>
 				<template v-slot:prepend>
-					<v-btn @click="()=>{
+					<v-btn class="mr-2"
+					 @click="()=>{
 						values = []
 						clearTriggerFunc()
-						}">全て選択解除</v-btn>
+					}">全て選択解除</v-btn>
+					
+					<slot name="help"></slot>
 				</template>
 			</v-list-item>
 			<v-divider class="mt-2"></v-divider>

--- a/src/views/MedicalInstitutionView.vue
+++ b/src/views/MedicalInstitutionView.vue
@@ -16,7 +16,11 @@
               v-model:values="manufacturerFilterValues" v-model:items="manufacturerFilterItems"
               :search-triger-func="searchTrigerFunc" :clear-trigger-func="clearTriggerFunc"
               label="製造販売業者"
-            ></SearchableSelectItems>
+            >
+              <template v-slot:help>
+                <ManufacturerHelpDialog></ManufacturerHelpDialog>
+              </template>
+            </SearchableSelectItems>
 
             <SearchableSelectItems v-else-if="item.type == 'vaccine_name'"
               v-model:values="vaccineNameFilterValues" v-model:items="vaccineNameFilterItems"
@@ -212,6 +216,7 @@ import SearchableSelectItems from '@/components/SearchableSelectItems.vue'
 import SelectItems from '@/components/SelectItems.vue'
 import NumberFilter from '@/components/NumberFilter.vue'
 import DateFilter from '@/components/DateFilter.vue'
+import ManufacturerHelpDialog from '@/components/ManufacturerHelpDialog.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'


### PR DESCRIPTION
同時接種するワクチンの製造販売業者に関する説明を追加し、それを表示するためのボタンを追加した。

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/4b97f39b-7a5e-4a05-ad56-005a52075cc6)

Close #22 