### PR TITLE
報告が多いロットNoに関する参考情報ページを、注意事項と共に追加する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import {
   SuspectedIssuesSubRoutes,
   MedialInstitutionHomeRoute,
   MedialInstitutionRoutes,
+  MedialInstitutionReferenceRoute,
   HealthHazardsHomeRoute,
   AboutRoute,
   HomeRoute,
@@ -95,6 +96,17 @@ export default {
           >
             <v-list-item-title class="sub-title suspeted-issue-sub">{{
               r.menu_name
+            }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item
+            :prepend-icon="MedialInstitutionReferenceRoute.icon"
+            :href="`${baseURL}#${MedialInstitutionReferenceRoute.path}`"
+            class="sub-icon suspeted-issue-sub"
+            :active="MedialInstitutionReferenceRoute.name === selectedItem"
+            @click="selectedItem = MedialInstitutionReferenceRoute.name"
+          >
+            <v-list-item-title class="sub-title suspeted-issue-sub">{{
+              MedialInstitutionReferenceRoute.menu_name
             }}</v-list-item-title>
           </v-list-item>
         </v-list-group>

--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -15,6 +15,7 @@ export const MedicalInstitutionSummaryURL = DatasetsURL + 'medical-institution-s
 export const CarditisReportsURL = DatasetsURL + 'carditis-reports.json'
 export const CarditisMetadataURL = DatasetsURL + 'carditis-metadata.json'
 export const CarditisSummaryURL = DatasetsURL + 'carditis-summary.json'
+export const CarditisSummaryFromReportsURL = DatasetsURL + 'carditis-summary-from-reports.json'
 
 export const DeathReportsURL = DatasetsURL + 'death-reports.json'
 export const DeathMetadataURL = DatasetsURL + 'death-metadata.json'

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -53,6 +53,13 @@ export const MedialInstitutionRoutes = [
     component: () => import('../views/MedicalInstitutionView.vue')
   },
 ]
+export const MedialInstitutionReferenceRoute = {
+  path: '/reference-of-medical-institution-reports',
+  name: '医療機関からの報告 - 副反応疑い報告の参考情報',
+  menu_name: '参考情報',
+  icon: 'mdi-information-outline',
+  component: () => import('../views/MedicalInstitutionReferenceView.vue')
+}
 
 export const HealthHazardsHomeRoute = {
   path: '/certified-health-hazard-summary',
@@ -86,6 +93,7 @@ export const AllRoutes = [
   ...SuspectedIssuesSubRoutes,
   MedialInstitutionHomeRoute,
   ...MedialInstitutionRoutes,
+  MedialInstitutionReferenceRoute,
   HealthHazardsHomeRoute,
   ...HealthHazardsSubRoutes
 ]

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -35,6 +35,13 @@ export const SuspectedIssuesSubRoutes = [
     icon: 'mdi-magnify',
     component: () => import('../views/DeathView.vue')
   },
+  {
+  path: '/reference-of-suspected-issues-reports',
+  name: '製造販売業者からの報告 - 参考情報',
+  menu_name: '参考情報',
+  icon: 'mdi-information-outline',
+  component: () => import('../views/SuspectedIssuesReferenceView.vue')
+}
 ]
 
 export const MedialInstitutionHomeRoute = {

--- a/src/types/CarditisSummaryFromReports.ts
+++ b/src/types/CarditisSummaryFromReports.ts
@@ -1,0 +1,9 @@
+import type { ILotNumberInformation } from "./LotNumberInfomation"
+
+export interface ICarditisSummaryFromReportsRoot {
+	carditis_summary_from_reports: ICarditisSummaryFromReports
+}
+
+export interface ICarditisSummaryFromReports {
+	lot_no_info: ILotNumberInformation
+}

--- a/src/types/DeathSummaryFromReports.ts
+++ b/src/types/DeathSummaryFromReports.ts
@@ -1,3 +1,5 @@
+import type { ILotNumberInformation } from "./LotNumberInfomation"
+
 export interface IDeathSummaryFromReportsRoot {
 	death_summary_from_reports: IDeathSummaryFromReports
 }
@@ -5,6 +7,7 @@ export interface IDeathSummaryFromReportsRoot {
 export interface IDeathSummaryFromReports {
 	date: string
 	sum_by_age: I2DItem[]
+	lot_no_info: ILotNumberInformation
 }
 
 export interface I2DItem {

--- a/src/types/LotNumberInfomation.ts
+++ b/src/types/LotNumberInfomation.ts
@@ -1,5 +1,6 @@
 export interface ILotNumberInformation {
 	top_ten_list: ILotNumberItem[]
+	top_ten_list_moderna: ILotNumberItem[]
 	invalid_count: number
 }
 

--- a/src/types/LotNumberInfomation.ts
+++ b/src/types/LotNumberInfomation.ts
@@ -1,0 +1,10 @@
+export interface ILotNumberInformation {
+	top_ten_list: ILotNumberItem[]
+	invalid_count: number
+}
+
+export interface ILotNumberItem {
+	lot_no: string
+	count: number
+	manufacturer: string
+}

--- a/src/types/MedicalInstitutionReports.ts
+++ b/src/types/MedicalInstitutionReports.ts
@@ -27,4 +27,10 @@ export interface IMedicalInstitutionSummaryFromReports {
 	total_count: string
 	sum_causal_relationship: [string, number][]
 	sum_severities_of_related: [string, number][]
+	lot_no_info: ILotNumberInformation
+}
+
+export interface ILotNumberInformation {
+	top_ten_list: [string, number][]
+	unknown_count: number
 }

--- a/src/types/MedicalInstitutionReports.ts
+++ b/src/types/MedicalInstitutionReports.ts
@@ -31,6 +31,12 @@ export interface IMedicalInstitutionSummaryFromReports {
 }
 
 export interface ILotNumberInformation {
-	top_ten_list: [string, number][]
+	top_ten_list: ILotNumberItem[]
 	invalid_count: number
+}
+
+export interface ILotNumberItem {
+	lot_no: string
+	count: number
+	manufacturer: string
 }

--- a/src/types/MedicalInstitutionReports.ts
+++ b/src/types/MedicalInstitutionReports.ts
@@ -1,4 +1,5 @@
 import type { ISourceInfo } from "./General"
+import type { ILotNumberInformation } from "./LotNumberInfomation"
 
 export interface IMedicalInstitutionReport {
 	no: number
@@ -28,15 +29,4 @@ export interface IMedicalInstitutionSummaryFromReports {
 	sum_causal_relationship: [string, number][]
 	sum_severities_of_related: [string, number][]
 	lot_no_info: ILotNumberInformation
-}
-
-export interface ILotNumberInformation {
-	top_ten_list: ILotNumberItem[]
-	invalid_count: number
-}
-
-export interface ILotNumberItem {
-	lot_no: string
-	count: number
-	manufacturer: string
 }

--- a/src/types/MedicalInstitutionReports.ts
+++ b/src/types/MedicalInstitutionReports.ts
@@ -32,5 +32,5 @@ export interface IMedicalInstitutionSummaryFromReports {
 
 export interface ILotNumberInformation {
 	top_ten_list: [string, number][]
-	unknown_count: number
+	invalid_count: number
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,6 +17,9 @@
             <v-col cols="12" lg="3" md="4" sm="6" v-for="(r, i) in MedialInstitutionRoutes" :key="i">
               <v-btn :prepend-icon="r.icon" size="x-large" :href="`${baseURL}#${r.path}`" min-width="17rem">{{ r.menu_name }}</v-btn>
             </v-col>
+            <v-col cols="12" lg="3" md="4" sm="6">
+              <v-btn :prepend-icon="MedialInstitutionReferenceRoute.icon" size="x-large" :href="`${baseURL}#${MedialInstitutionReferenceRoute.path}`" min-width="17rem">{{ MedialInstitutionReferenceRoute.menu_name }}</v-btn>
+            </v-col>
           </v-row>
         </v-container>
 
@@ -141,7 +144,8 @@ import {
   SuspectedIssuesHomeRoute,
   SuspectedIssuesSubRoutes,
   MedialInstitutionHomeRoute,
-  MedialInstitutionRoutes
+  MedialInstitutionRoutes,
+  MedialInstitutionReferenceRoute
 } from '@/router/routes'
 import { shallowRef } from 'vue'
 import router from '@/router/index'

--- a/src/views/MedicalInstitutionReferenceView.vue
+++ b/src/views/MedicalInstitutionReferenceView.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-container fluid>
+
+    <v-container v-if="medicalInstitutionSummary == undefined">
+      <v-progress-circular color="primary" indeterminate :size="100" :width="10"></v-progress-circular>
+    </v-container>
+
+    <v-container v-else>
+      <h4 class="text-h4 mb-5">参考情報</h4>
+
+      <v-card class="mx-auto mb-10" elevation="6">
+        <template v-slot:title>
+          <span class="font-weight-black">注意事項</span>
+        </template>
+        <v-card-text class="text-body-1">
+          <v-row>
+            <v-col cols="1">
+              <v-img src="mdi-alert-decagram-outline.jpeg"></v-img>
+              <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
+            </v-col>
+            <v-col cols="11">
+              <p class="text-body-1">
+                このページの内容は、膨大な副反応疑い報告から考察・調査を行う糸口を掴んでいただく一助となることを意図しております。
+                <span class="wave-under-bar">特定ロットNoと報告の多寡は複合的な要因が関連する情報であり、<span
+                    class="big-bold">直接的な因果関係は実証されていません。</span>
+                  あくまでも「 <span class="big-bold">参考情報</span> 」としてご活用ください。</span>
+              </p>
+            </v-col>
+          </v-row>
+
+        </v-card-text>
+      </v-card>
+
+      <h5 class="text-h5 mb-2">ロットNoによる集計</h5>
+      <p class="text-body-1 mb-7">
+        ロットNoが不明・空白の報告は <span class="big-bold">{{
+          medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.invalid_count.toLocaleString()
+          }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
+      </p>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="modernaLotNumberOptions" :series="[{data: modernaLotNumberSeries}]">
+          </apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧（モデルナのみ）</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in modernaLotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <p class="text-caption text-right">※ このページは <b>{{
+          medicalInstitutionSummary?.medical_institution_summary_from_reports.date }}</b> 時点までの報告内容に基づいた集計結果を表示しています。
+      </p>
+    </v-container>
+
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted, shallowRef } from 'vue'
+import axios from 'axios'
+import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
+import router from '@/router/index'
+import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
+import type { ILotNumberItem } from '@/types/LotNumberInfomation'
+import { CreateBarChartOption } from '@/tools/ChartOptions'
+
+AppBarTitle.value = String(router.currentRoute.value.name)
+AppBarColor.value = 'blue-accent-1'
+
+const medicalInstitutionSummary = shallowRef<IMedicalInstitutionSummary>()
+onMounted(() => {
+  axios
+    .get<IMedicalInstitutionSummary>(MedicalInstitutionSummaryURL)
+    .then((response) => {
+      medicalInstitutionSummary.value = response.data
+
+      const top_ten_list = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list
+      const lot_no_data = []
+      for (let index = 0; index < top_ten_list.length; index++) {
+        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
+      }
+      lotNumberSeries.value = lot_no_data
+      lotNumberTopTenList.value = top_ten_list
+
+      const moderna_top_ten_list = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list_moderna
+      const moderna_lot_no_data = []
+      for (let index = 0; index < moderna_top_ten_list.length; index++) {
+        moderna_lot_no_data.push({x: moderna_top_ten_list[index].lot_no, y: moderna_top_ten_list[index].count})
+      }
+      modernaLotNumberSeries.value = moderna_lot_no_data
+      modernaLotNumberTopTenList.value = moderna_top_ten_list
+   
+      // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
+      window.dispatchEvent(new Event('resize'))
+    })
+    .catch((error) => console.log('failed to get medical insutitution summary data: ' + error))
+})
+
+const lotNumberSeries = shallowRef<any[]>([])
+const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
+const lotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const modernaLotNumberSeries = shallowRef<any[]>([])
+const modernaLotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種（モデルナのみ）')
+const modernaLotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const createUrl = (value: string) => {
+  return '#/reports-from-medical-institution?ln=' + value
+}
+</script>
+
+<style scoped lang="css">
+.big-bold {
+  font-size: 1.4rem;
+  font-weight: bolder;
+}
+
+.wave-under-bar{
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+</style>

--- a/src/views/MedicalInstitutionReferenceView.vue
+++ b/src/views/MedicalInstitutionReferenceView.vue
@@ -15,7 +15,6 @@
         <v-card-text class="text-body-1">
           <v-row>
             <v-col cols="1">
-              <v-img src="mdi-alert-decagram-outline.jpeg"></v-img>
               <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
             </v-col>
             <v-col cols="11">

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -11,9 +11,14 @@
     </v-container>
 
     <v-container v-else>
-      <h4 class="text-h4">副反応疑い報告</h4>
-      <p>
-        予防接種法により医療機関から報告された事例 <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.total_count.toLocaleString() }} [件]</b> の集計結果を示します。
+      <h4 class="text-h4 mb-2">副反応疑い報告</h4>
+      <p class="text-body-1 mb-5">
+        予防接種法に基づいて医療機関から報告された副反応疑い報告 <span class="big-bold">{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.total_count.toLocaleString() }}</span> [件] の集計結果を示します。
+      </p>
+
+      <h5 class="text-h5 mb-2">報告医の評価</h5>
+      <p class="text-body-1 mb-1">
+        報告医による因果関係評価の内訳や、報告医が関連の有無を評価した結果の内訳です。
       </p>
 
       <div class="d-flex justify-end">
@@ -21,7 +26,7 @@
         <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
       </div>
 
-      <v-row>
+      <v-row class="mb-5">
         <v-col cols="12" sm="6">
           <apexchart :options="causalRelationshipOptions" :series="causalRelationshipSeries"></apexchart>
         </v-col>
@@ -31,26 +36,26 @@
         </v-col>
       </v-row>
 
+      <h5 class="text-h5 mb-2">ロットNoによる集計</h5>
+      <p class="text-body-1 mb-2">
+        ロットNoが不明・空白の報告は <span class="big-bold">{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
+      </p>
       <v-row>
         <v-col cols="12" sm="6">
           <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
-          <p class="text-caption text-right">※ ロットNoが不明または空白の報告は <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</b> 件で、上記はそれらを除いた集計結果です。</p>
         </v-col>
 
-        <v-col cols="12" sm="6">
-          <p class="text-body-1 mb-5">
-            以下の一覧でロットNoを選択すると、報告一覧に対してそのロットNoを含む報告のみを表示できます。
-          </p>
-          <ol class="pl-10">
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧</b>
+          <ol class="pl-10 mt-2">
             <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
-              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ( 製造販売業者: {{ lotno_data.manufacturer }} )
+              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{ lotno_data.manufacturer }})
             </li>
           </ol>
-          <p class="text-caption text-left mt-4">※ 左上の集計数は対象のロットNoのみ接種した報告の数です。報告一覧では同時接種したワクチンなどを含む報告も表示されるため、件数が異なる場合があります。</p>
+          <p class="text-caption text-left mt-4">※ 報告一覧では同時接種したワクチンを含む報告も表示されるため、件数が異なる場合があります。</p>
         </v-col>
       </v-row>
 
-      <br>
       <p class="text-caption text-right">※ このページは <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.date }}</b> 時点までの報告内容に基づいた集計結果を表示しています。</p>
     </v-container>
 
@@ -125,4 +130,9 @@ const createUrl = (value: string) => {
 }
 </script>
 
-<style lang="scss"></style>
+<style lang="css">
+.big-bold {
+  font-size: 1.4rem;
+  font-weight: bolder;
+}
+</style>

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -31,8 +31,26 @@
         </v-col>
       </v-row>
 
+      <v-row>
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
+          <p class="text-caption text-right">※ ロットNoが不明な報告は <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.unknown_count }}</b> 件で、上記はそれらを除いた集計結果です。</p>
+        </v-col>
+
+        <v-col cols="12" sm="6">
+          <p class="text-body-1 mb-5">
+            以下の一覧でロットNoを選択すると、そのロットNoでフィルタリングした報告一覧を表示できます。
+          </p>
+          <ol class="pl-10">
+            <li v-for="(lotno_data, i) in lotNumberSeries" :key="i" class="mb-3">
+              <a :href="createUrl(lotno_data.x)" target="_blank"><b>{{ lotno_data.x }}</b></a> ( {{ lotno_data.y }} 件 )
+            </li>
+          </ol>
+        </v-col>
+      </v-row>
+
       <br>
-      <p class="text-caption text-right">※ <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.date }}</b> 時点までの集計結果を用いています。</p>
+      <p class="text-caption text-right">※ このページは <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.date }}</b> 時点までの報告内容に基づいた集計結果を表示しています。</p>
     </v-container>
 
   </v-container>
@@ -44,7 +62,7 @@ import axios from 'axios'
 import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
 import router from '@/router/index'
 import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
-import { CreatePieChartOption } from '@/tools/ChartOptions'
+import { CreateBarChartOption, CreatePieChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
@@ -67,6 +85,13 @@ onMounted(() => {
         severityLabels.value.push(Object.keys(ss)[index])      
       }
       severitySeries.value = Object.values(ss)
+
+      const ln = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list
+      const lot_no_data = []
+      for (let index = 0; index < Object.keys(ln).length; index++) {
+        lot_no_data.push({x: Object.keys(ln)[index], y: Object.values(ln)[index]})
+      }
+      lotNumberSeries.value = lot_no_data
    
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -84,9 +109,19 @@ const severityLabels = shallowRef<string[]>([])
 const severitySeries = shallowRef<any[]>([])
 const severityOptions = CreatePieChartOption('「関連あり」案件の重篤度による内訳', severityLabels, isPersentView)
 
+const lotNumberSeries = shallowRef<any[]>([])
+const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
+
 const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
+}
+
+const navigateWithQuery = (value: string) => {
+  router.push({ path: 'reports-from-medical-institution', query: { ln: value } })
+}
+const createUrl = (value: string) => {
+  return '#/reports-from-medical-institution?ln=' + value
 }
 </script>
 

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -36,26 +36,6 @@
         </v-col>
       </v-row>
 
-      <h5 class="text-h5 mb-2">ロットNoによる集計</h5>
-      <p class="text-body-1 mb-2">
-        ロットNoが不明・空白の報告は <span class="big-bold">{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
-      </p>
-      <v-row>
-        <v-col cols="12" sm="6">
-          <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
-        </v-col>
-
-        <v-col cols="12" sm="6" class="mt-2">
-          <b>ロットNoのリンク一覧</b>
-          <ol class="pl-10 mt-2">
-            <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
-              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{ lotno_data.manufacturer }})
-            </li>
-          </ol>
-          <p class="text-caption text-left mt-4">※ 報告一覧では同時接種したワクチンを含む報告も表示されるため、件数が異なる場合があります。</p>
-        </v-col>
-      </v-row>
-
       <p class="text-caption text-right">※ このページは <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.date }}</b> 時点までの報告内容に基づいた集計結果を表示しています。</p>
     </v-container>
 
@@ -68,8 +48,7 @@ import axios from 'axios'
 import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
 import router from '@/router/index'
 import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
-import type { ILotNumberItem } from '@/types/LotNumberInfomation'
-import { CreateBarChartOption, CreatePieChartOption } from '@/tools/ChartOptions'
+import { CreatePieChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
@@ -93,14 +72,6 @@ onMounted(() => {
       }
       severitySeries.value = Object.values(ss)
 
-      const top_ten_list = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list
-      const lot_no_data = []
-      for (let index = 0; index < top_ten_list.length; index++) {
-        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
-      }
-      lotNumberSeries.value = lot_no_data
-      lotNumberTopTenList.value = top_ten_list
-   
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
     })
@@ -117,17 +88,9 @@ const severityLabels = shallowRef<string[]>([])
 const severitySeries = shallowRef<any[]>([])
 const severityOptions = CreatePieChartOption('「関連あり」案件の重篤度による内訳', severityLabels, isPersentView)
 
-const lotNumberSeries = shallowRef<any[]>([])
-const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
-const lotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
-
 const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
-}
-
-const createUrl = (value: string) => {
-  return '#/reports-from-medical-institution?ln=' + value
 }
 </script>
 

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -34,7 +34,7 @@
       <v-row>
         <v-col cols="12" sm="6">
           <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
-          <p class="text-caption text-right">※ ロットNoが不明な報告は <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.unknown_count }}</b> 件で、上記はそれらを除いた集計結果です。</p>
+          <p class="text-caption text-right">※ ロットNoが不明または空白の報告は <b>{{ medicalInstitutionSummary?.medical_institution_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</b> 件で、上記はそれらを除いた集計結果です。</p>
         </v-col>
 
         <v-col cols="12" sm="6">

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -67,7 +67,8 @@ import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
 import router from '@/router/index'
-import { type ILotNumberItem, type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
+import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
+import type { ILotNumberItem } from '@/types/LotNumberInfomation'
 import { CreateBarChartOption, CreatePieChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
@@ -130,7 +131,7 @@ const createUrl = (value: string) => {
 }
 </script>
 
-<style lang="css">
+<style scoped lang="css">
 .big-bold {
   font-size: 1.4rem;
   font-weight: bolder;

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -39,13 +39,14 @@
 
         <v-col cols="12" sm="6">
           <p class="text-body-1 mb-5">
-            以下の一覧でロットNoを選択すると、そのロットNoでフィルタリングした報告一覧を表示できます。
+            以下の一覧でロットNoを選択すると、報告一覧に対してそのロットNoを含む報告のみを表示できます。
           </p>
           <ol class="pl-10">
-            <li v-for="(lotno_data, i) in lotNumberSeries" :key="i" class="mb-3">
-              <a :href="createUrl(lotno_data.x)" target="_blank"><b>{{ lotno_data.x }}</b></a> ( {{ lotno_data.y }} 件 )
+            <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ( 製造販売業者: {{ lotno_data.manufacturer }} )
             </li>
           </ol>
+          <p class="text-caption text-left mt-4">※ 左上の集計数は対象のロットNoのみ接種した報告の数です。報告一覧では同時接種したワクチンなどを含む報告も表示されるため、件数が異なる場合があります。</p>
         </v-col>
       </v-row>
 
@@ -61,7 +62,7 @@ import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
 import router from '@/router/index'
-import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
+import { type ILotNumberItem, type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
 import { CreateBarChartOption, CreatePieChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
@@ -86,12 +87,13 @@ onMounted(() => {
       }
       severitySeries.value = Object.values(ss)
 
-      const ln = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list
+      const top_ten_list = medicalInstitutionSummary.value.medical_institution_summary_from_reports.lot_no_info.top_ten_list
       const lot_no_data = []
-      for (let index = 0; index < Object.keys(ln).length; index++) {
-        lot_no_data.push({x: Object.keys(ln)[index], y: Object.values(ln)[index]})
+      for (let index = 0; index < top_ten_list.length; index++) {
+        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
       }
       lotNumberSeries.value = lot_no_data
+      lotNumberTopTenList.value = top_ten_list
    
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -111,15 +113,13 @@ const severityOptions = CreatePieChartOption('「関連あり」案件の重篤�
 
 const lotNumberSeries = shallowRef<any[]>([])
 const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
+const lotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
 
 const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
 }
 
-const navigateWithQuery = (value: string) => {
-  router.push({ path: 'reports-from-medical-institution', query: { ln: value } })
-}
 const createUrl = (value: string) => {
   return '#/reports-from-medical-institution?ln=' + value
 }

--- a/src/views/SuspectedIssuesReferenceView.vue
+++ b/src/views/SuspectedIssuesReferenceView.vue
@@ -1,0 +1,227 @@
+<template>
+  <v-container fluid>
+
+    <v-container v-if="carditisSummary == undefined">
+      <v-progress-circular color="primary" indeterminate :size="100" :width="10"></v-progress-circular>
+    </v-container>
+
+    <v-container v-else>
+      <h4 class="text-h4 mb-5">参考情報</h4>
+
+      <v-card class="mx-auto mb-10" elevation="6">
+        <template v-slot:title>
+          <span class="font-weight-black">注意事項</span>
+        </template>
+        <v-card-text class="text-body-1">
+          <v-row>
+            <v-col cols="1">
+              <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
+            </v-col>
+            <v-col cols="11">
+              <p class="text-body-1">
+                このページの内容は、膨大な心筋炎/心膜炎報告や亡くなった方々の報告（いずれも製造販売業者からの副反応疑い報告が母集団）から考察・調査を行う糸口を掴んでいただく一助となることを意図しております。
+                <span class="wave-under-bar">特定ロットNoと報告の多寡は複合的な要因が関連する情報であり、<span class="big-bold">直接的な因果関係は実証されていません。</span>
+                あくまでも「 <span class="big-bold">参考情報</span> 」としてご活用ください。</span>
+              </p>
+            </v-col>
+          </v-row>
+
+        </v-card-text>
+      </v-card>
+
+      <h5 class="text-h5 mt-4 mb-2">ロットNoによる集計（心筋炎/心膜炎）</h5>
+      <p class="text-body-1 mb-7">
+        ロットNoが不明・空白の報告は <span class="big-bold">{{
+          carditisSummary?.carditis_summary_from_reports.lot_no_info.invalid_count.toLocaleString()
+          }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
+      </p>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="carditisLotNumberOptions" :series="[{data: carditisLotNumberSeries}]"></apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in carditisLotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrlForCarditis(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="carditisModernaLotNumberOptions" :series="[{data: carditisModernaLotNumberSeries}]">
+          </apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧（モデルナのみ）</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in carditisModernaLotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrlForCarditis(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <h5 class="text-h5 mt-4 mb-2">ロットNoによる集計（亡くなった方々）</h5>
+      <p class="text-body-1 mb-7">
+        ロットNoが不明・空白の報告は <span class="big-bold">{{
+          deathSummary?.death_summary_from_reports.lot_no_info.invalid_count.toLocaleString()
+          }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
+      </p>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="deathLotNumberOptions" :series="[{data: deathLotNumberSeries}]"></apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in deathLotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrlForDeath(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <v-row class="mb-2">
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="deathModernaLotNumberOptions" :series="[{data: deathModernaLotNumberSeries}]">
+          </apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧（モデルナのみ）</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in deathModernaLotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrlForDeath(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{
+              lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ リンク先の報告一覧では「同時接種したワクチン」を含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <p class="text-caption text-right">※ このページは <b>{{ deathSummary?.death_summary_from_reports.date }}</b> 時点までの報告内容に基づいた集計結果を表示しています。
+      </p>
+    </v-container>
+
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted, shallowRef } from 'vue'
+import axios from 'axios'
+import { AppBarTitle, AppBarColor, CarditisSummaryFromReportsURL, DeathSummaryFromReportsURL } from '@/router/data'
+import router from '@/router/index'
+import type { ILotNumberItem } from '@/types/LotNumberInfomation'
+import { CreateBarChartOption } from '@/tools/ChartOptions'
+import type { ICarditisSummaryFromReportsRoot } from '@/types/CarditisSummaryFromReports'
+import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
+
+AppBarTitle.value = String(router.currentRoute.value.name)
+AppBarColor.value = 'blue-accent-1'
+
+const carditisSummary = shallowRef<ICarditisSummaryFromReportsRoot>()
+const deathSummary = shallowRef<IDeathSummaryFromReportsRoot>()
+onMounted(() => {
+  axios
+    .get<ICarditisSummaryFromReportsRoot>(CarditisSummaryFromReportsURL)
+    .then((response) => {
+      carditisSummary.value = response.data
+
+      const top_ten_list = carditisSummary.value.carditis_summary_from_reports.lot_no_info.top_ten_list
+      const lot_no_data = []
+      for (let index = 0; index < top_ten_list.length; index++) {
+        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
+      }
+      carditisLotNumberSeries.value = lot_no_data
+      carditisLotNumberTopTenList.value = top_ten_list
+
+      const moderna_top_ten_list = carditisSummary.value.carditis_summary_from_reports.lot_no_info.top_ten_list_moderna
+      const moderna_lot_no_data = []
+      for (let index = 0; index < moderna_top_ten_list.length; index++) {
+        moderna_lot_no_data.push({x: moderna_top_ten_list[index].lot_no, y: moderna_top_ten_list[index].count})
+      }
+      carditisModernaLotNumberSeries.value = moderna_lot_no_data
+      carditisModernaLotNumberTopTenList.value = moderna_top_ten_list
+   
+      // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
+      window.dispatchEvent(new Event('resize'))
+    })
+    .catch((error) => console.log('failed to get carditis summary data: ' + error))
+
+  axios
+    .get<IDeathSummaryFromReportsRoot>(DeathSummaryFromReportsURL)
+    .then((response) => {
+      deathSummary.value = response.data
+
+      const top_ten_list = deathSummary.value.death_summary_from_reports.lot_no_info.top_ten_list
+      const lot_no_data = []
+      for (let index = 0; index < top_ten_list.length; index++) {
+        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
+      }
+      deathLotNumberSeries.value = lot_no_data
+      deathLotNumberTopTenList.value = top_ten_list
+
+      const moderna_top_ten_list = deathSummary.value.death_summary_from_reports.lot_no_info.top_ten_list_moderna
+      const moderna_lot_no_data = []
+      for (let index = 0; index < moderna_top_ten_list.length; index++) {
+        moderna_lot_no_data.push({x: moderna_top_ten_list[index].lot_no, y: moderna_top_ten_list[index].count})
+      }
+      deathModernaLotNumberSeries.value = moderna_lot_no_data
+      deathModernaLotNumberTopTenList.value = moderna_top_ten_list
+   
+      // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
+      window.dispatchEvent(new Event('resize'))
+    })
+    .catch((error) => console.log('failed to get death summary data: ' + error))
+})
+
+const carditisLotNumberSeries = shallowRef<any[]>([])
+const carditisLotNumberOptions = CreateBarChartOption('心筋炎/心膜炎の報告が多いロットNoの上位10種')
+const carditisLotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const carditisModernaLotNumberSeries = shallowRef<any[]>([])
+const carditisModernaLotNumberOptions = CreateBarChartOption('心筋炎/心膜炎の報告が多いロットNoの上位10種（モデルナのみ）')
+const carditisModernaLotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const createUrlForCarditis = (value: string) => {
+  return '#/reported-myocarditis-issues?ln=' + value
+}
+
+const deathLotNumberSeries = shallowRef<any[]>([])
+const deathLotNumberOptions = CreateBarChartOption('亡くなった方の報告が多いロットNoの上位10種')
+const deathLotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const deathModernaLotNumberSeries = shallowRef<any[]>([])
+const deathModernaLotNumberOptions = CreateBarChartOption('亡くなった方の報告が多いロットNoの上位10種（モデルナのみ）')
+const deathModernaLotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+
+const createUrlForDeath = (value: string) => {
+  return '#/reported-death-issues?ln=' + value
+}
+</script>
+
+<style scoped lang="css">
+.big-bold {
+  font-size: 1.4rem;
+  font-weight: bolder;
+}
+
+.wave-under-bar{
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+</style>

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -117,26 +117,6 @@
         </v-col>
       </v-row>
 
-      <h5 class="text-h5 mt-5 mb-2">ロットNoによる集計</h5>
-      <p class="text-body-1 mb-2">
-        ロットNoが不明・空白の報告は <span class="big-bold">{{ carditisSummaryDataFromReports?.carditis_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
-      </p>
-      <v-row>
-        <v-col cols="12" sm="6">
-          <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
-        </v-col>
-
-        <v-col cols="12" sm="6" class="mt-2">
-          <b>ロットNoのリンク一覧</b>
-          <ol class="pl-10 mt-2">
-            <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
-              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{ lotno_data.manufacturer }})
-            </li>
-          </ol>
-          <p class="text-caption text-left mt-4">※ 報告一覧では同時接種したワクチンを含む報告も表示されるため、件数が異なる場合があります。</p>
-        </v-col>
-      </v-row>
-
       <p class="text-caption text-right mt-2">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」で
       発表された資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
@@ -266,21 +246,17 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, CarditisSummaryFromReportsURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL } from '@/router/data'
 import router from '@/router/index'
 import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
-import type { ICarditisSummaryFromReportsRoot } from '@/types/CarditisSummaryFromReports'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
-import type { ILotNumberItem } from '@/types/LotNumberInfomation'
-import { CreateBarChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
 
 const carditisSummaryData = shallowRef<ICarditisSummaryRoot>()
-const carditisSummaryDataFromReports = shallowRef<ICarditisSummaryFromReportsRoot>()
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()
 const deathSummaryDataFromReports = shallowRef<IDeathSummaryFromReportsRoot>()
 onMounted(() => {
@@ -307,24 +283,6 @@ onMounted(() => {
     })
     .catch((error) => console.log('failed to get carditis summary data: ' + error))
   
-  axios
-    .get<ICarditisSummaryFromReportsRoot>(CarditisSummaryFromReportsURL)
-    .then((response) => {
-      carditisSummaryDataFromReports.value = response.data
-
-      const top_ten_list = carditisSummaryDataFromReports.value.carditis_summary_from_reports.lot_no_info.top_ten_list
-      const lot_no_data = []
-      for (let index = 0; index < top_ten_list.length; index++) {
-        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
-      }
-      lotNumberSeries.value = lot_no_data
-      lotNumberTopTenList.value = top_ten_list
-
-      // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
-      window.dispatchEvent(new Event('resize'))
-    })
-    .catch((error) => console.log('failed to get carditis summary from reports data: ' + error))
-
   axios
     .get<IDeathSummaryRoot>(DeathSummaryURL)
     .then((response) => {
@@ -646,13 +604,6 @@ const addNewLineWithBrackets = (label: string): string => {
     joined += '(' + split[index];
   }
   return joined
-}
-
-const lotNumberSeries = shallowRef<any[]>([])
-const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
-const lotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
-const createUrl = (value: string) => {
-  return '#/reported-myocarditis-issues?ln=' + value
 }
 </script>
 

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -2,8 +2,8 @@
   <v-container fluid>
 
     <v-container>
-      <h4 class="text-h4">副反応疑い報告</h4>
-      <p>（製造販売業者からの副反応疑い報告に関するまとめをここに掲載予定）</p>
+      <h4 class="text-h4 mb-2">副反応疑い報告</h4>
+      <p class="text-body-1">（製造販売業者からの副反応疑い報告に関するまとめをここに掲載予定）</p>
     </v-container>
 
     <v-container v-if="carditisSummaryData == undefined">
@@ -17,9 +17,9 @@
 
     <v-container v-else>
 
-      <h4 class="text-h4">心筋炎/心膜炎 報告</h4>
-      <p>
-        「新型コロナワクチン接種後の心筋炎又は心膜炎疑い」として製造販売業者から報告された事例 <b>{{ carditisSummaryData?.carditis_summary.total.toLocaleString() }} [件]</b> の集計結果を示します。
+      <h4 class="text-h4 mb-1">心筋炎/心膜炎 報告</h4>
+      <p class="text-body-1">
+        「新型コロナワクチン接種後の心筋炎又は心膜炎疑い」として製造販売業者から報告された <span class="big-bold">{{ carditisSummaryData?.carditis_summary.total.toLocaleString() }}</span> [件] の集計結果を示します。
       </p>
 
       <div class="d-flex justify-end">
@@ -28,20 +28,20 @@
       </div>
 
       <v-row>
-        <v-col cols="12" sm="6">
+        <v-col cols="12" sm="8">
           <apexchart :options="carditisSummaryOptions" :series="carditisSummarySeries"></apexchart>
         </v-col>
-        <v-col cols="12" sm="6">
+        <v-col cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-left">心筋炎件数</th>
+                <th class="text-left">症状名</th>
+                <th class="text-right">件数</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="label, index in ['心筋炎', '心膜炎']" :key="label">
-                <td>{{ label }}</td>
+                <td style="white-space: pre;">{{ label }}</td>
                 <td class="text-right">{{ carditisSummarySeries[index].toLocaleString() }}</td>
               </tr>
               <tr>
@@ -51,12 +51,19 @@
             </tbody>
           </v-table>
         </v-col>
+      </v-row>
 
-        <v-col cols="12" sm="6">
+      <h5 class="text-h5 mt-5 mb-1">心筋炎の件数内訳</h5>
+      <div class="d-flex justify-end">
+        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
+        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      </div>
+      <v-row>
+        <v-col cols="12" sm="8">
           <apexchart :options="myocarditisByVaccineOptions" :series="myocarditisByVaccineSeries"></apexchart>
         </v-col>
 
-        <v-col  cols="12" sm="6">
+        <v-col  cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
@@ -66,32 +73,39 @@
             </thead>
             <tbody>
               <tr v-for="label, index in myocarditisByVaccineLabels" :key="label">
-                <td>{{ label }}</td>
+                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
                 <td class="text-right">{{ myocarditisByVaccineSeries[index].toLocaleString() }}</td>
               </tr>
               <tr>
                 <td><b>合計</b></td>
-                <td class="text-right"><b>{{ myocarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
+                <td class="text-right text-body-2"><b>{{ myocarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
               </tr>
             </tbody>
           </v-table>
         </v-col>
+      </v-row>
 
-        <v-col cols="12" sm="6">
+      <h5 class="text-h5 mt-5 mb-2">心膜炎の件数内訳</h5>
+      <div class="d-flex justify-end">
+        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
+        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      </div>
+      <v-row>
+        <v-col cols="12" sm="8">
           <apexchart :options="pericarditisByVaccineOptions" :series="pericarditisByVaccineSeries"></apexchart>
         </v-col>
 
-        <v-col  cols="12" sm="6">
+        <v-col  cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
                 <th class="text-left">ワクチン名</th>
-                <th class="text-left">心筋炎件数</th>
+                <th class="text-left">心膜炎件数</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="label, index in pericarditisByVaccineLabels" :key="label">
-                <td>{{ label }}</td>
+                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
                 <td class="text-right">{{ pericarditisByVaccineSeries[index].toLocaleString() }}</td>
               </tr>
               <tr>
@@ -118,27 +132,28 @@
     </v-container>
 
     <v-container v-else>
-      <h4 class="text-h4">亡くなった方に関する報告</h4>
-      <p>
-        「新型コロナワクチン接種後の死亡例」として製造販売業者から報告された事例 <b>{{ deathSummaryData?.death_summary.sum_by_evaluation.total.toLocaleString() }} [件]</b> の集計結果を示します。
+      <h4 class="text-h4 mt-5 mb-2">亡くなった方々に関する報告</h4>
+      <p class="text-body-1">
+        「新型コロナワクチン接種後の死亡例」として製造販売業者から報告された事例 <span class="big-bold">{{ deathSummaryData?.death_summary.sum_by_evaluation.total.toLocaleString() }}</span> [件] の集計結果を示します。
       </p>
 
+      <h5 class="text-h5 mt-5 mb-1">因果関係評価の内訳</h5>
       <div class="d-flex justify-end">
         <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
         <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
       </div>
 
       <v-row>
-        <v-col cols="12" sm="6">
+        <v-col cols="12" sm="8">
           <apexchart :options="deathSummaryOptions" :series="deathSummarySeries"></apexchart>
         </v-col>
 
-        <v-col  cols="12" sm="6">
+        <v-col  cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
                 <th class="text-left">評価結果</th>
-                <th class="text-left">件数</th>
+                <th class="text-right">件数</th>
               </tr>
             </thead>
             <tbody>
@@ -163,21 +178,21 @@
           <EvaluationResultHelpDialog></EvaluationResultHelpDialog>
         </v-col>
 
-        <v-col cols="12" sm="6">
-          <apexchart height="400" :options="deathSummaryByVaccineOptions" :series="deathSummaryByVaccineSeries"></apexchart>
+        <v-col cols="12" sm="8">
+          <apexchart :options="deathSummaryByVaccineOptions" :series="deathSummaryByVaccineSeries"></apexchart>
         </v-col>
 
-        <v-col  cols="12" sm="6">
+        <v-col  cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
                 <th class="text-left">ワクチン名</th>
-                <th class="text-left">α・γの件数</th>
+                <th class="text-right">α・γの件数</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="label, index in deathSummaryByVaccineLabels" :key="label">
-                <td>{{ label }}</td>
+                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
                 <td class="text-right">{{ deathSummaryByVaccineSeries[index].toLocaleString() }}</td>
               </tr>
               <tr>
@@ -187,10 +202,8 @@
             </tbody>
           </v-table>
         </v-col>
-
       </v-row>
 
-      <br>
       <p class="text-caption text-right">※ 「 <a :href="deathSummaryData?.death_summary.source.url">{{ deathSummaryData?.death_summary.source.name }}</a> 」で
       発表された資料の <b>{{ deathSummaryData?.death_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
@@ -205,10 +218,7 @@
     </v-container>
 
     <v-container v-else>
-      <p>
-        以降のグラフは、亡くなった方の症例一覧（{{ deathSummaryDataFromReports.death_summary_from_reports.date }} 時点の数値）を用いています。
-      </p>
-      <br>
+      <h5 class="text-h5 mt-5 mb-2">年代別の内訳</h5>
 
       <v-row>
         <v-col cols="12">
@@ -218,7 +228,7 @@
             :options="{
               chart: { id: 'number_of_deaths_reported_by_age_group' },
               colors: ['#c83f3d'],
-              title: { text: '亡くなられた方の人数（年代別）', floating: true },
+              title: { text: '亡くなられた方々の人数（年代別）', floating: true },
               xaxis: {
                 title: { text: '人数 (人)' },
               },
@@ -229,6 +239,7 @@
           ></apexchart>
         </v-col>
       </v-row>
+      <p class="text-caption text-right">※ <b>{{ deathSummaryDataFromReports.death_summary_from_reports.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
   </v-container>
@@ -582,6 +593,33 @@ const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
 }
+
+const addNewLineWithBrackets = (label: string): string => {
+  label = label.replace('（','(')
+  label = label.replace('）',')')
+  
+  let split = label.split('(')
+  if(split.length < 2) return label
+
+  let joined = split[0] + '\r\n'
+  for (let index = 1; index < split.length; index++) {
+    joined += '(' + split[index];
+  }
+  return joined
+}
 </script>
 
-<style lang="scss"></style>
+<style scoped lang="css">
+.big-bold {
+  font-size: 1.4rem;
+  font-weight: bolder;
+}
+
+.v-table {
+  white-space: pre-line;
+}
+
+.small-cell {
+  font-size: 0.9rem
+}
+</style>

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -117,8 +117,27 @@
         </v-col>
       </v-row>
 
-      <br>
-      <p class="text-caption text-right">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」で
+      <h5 class="text-h5 mt-5 mb-2">ロットNoによる集計</h5>
+      <p class="text-body-1 mb-2">
+        ロットNoが不明・空白の報告は <span class="big-bold">{{ carditisSummaryDataFromReports?.carditis_summary_from_reports.lot_no_info.invalid_count.toLocaleString() }}</span> [件] です。以下の集計は、それらを除いた結果に基づいた上位10種を示しています。
+      </p>
+      <v-row>
+        <v-col cols="12" sm="6">
+          <apexchart height="400" :options="lotNumberOptions" :series="[{data: lotNumberSeries}]"></apexchart>
+        </v-col>
+
+        <v-col cols="12" sm="6" class="mt-2">
+          <b>ロットNoのリンク一覧</b>
+          <ol class="pl-10 mt-2">
+            <li v-for="(lotno_data, i) in lotNumberTopTenList" :key="i" class="mb-2">
+              <a :href="createUrl(lotno_data.lot_no)" target="_blank"><b>{{ lotno_data.lot_no }}</b></a> ({{ lotno_data.manufacturer }})
+            </li>
+          </ol>
+          <p class="text-caption text-left mt-4">※ 報告一覧では同時接種したワクチンを含む報告も表示されるため、件数が異なる場合があります。</p>
+        </v-col>
+      </v-row>
+
+      <p class="text-caption text-right mt-2">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」で
       発表された資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
@@ -203,9 +222,6 @@
           </v-table>
         </v-col>
       </v-row>
-
-      <p class="text-caption text-right">※ 「 <a :href="deathSummaryData?.death_summary.source.url">{{ deathSummaryData?.death_summary.source.name }}</a> 」で
-      発表された資料の <b>{{ deathSummaryData?.death_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
     <v-container v-if="deathSummaryDataFromReports == undefined">
@@ -239,7 +255,9 @@
           ></apexchart>
         </v-col>
       </v-row>
-      <p class="text-caption text-right">※ <b>{{ deathSummaryDataFromReports.death_summary_from_reports.date }}</b> 時点の数値を用いています。</p>
+      
+      <p class="text-caption text-right mt-2">※ 「 <a :href="deathSummaryData?.death_summary.source.url">{{ deathSummaryData?.death_summary.source.name }}</a> 」で
+      発表された資料の <b>{{ deathSummaryData?.death_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
   </v-container>
@@ -248,17 +266,21 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, CarditisSummaryFromReportsURL } from '@/router/data'
 import router from '@/router/index'
 import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
+import type { ICarditisSummaryFromReportsRoot } from '@/types/CarditisSummaryFromReports'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
+import type { ILotNumberItem } from '@/types/LotNumberInfomation'
+import { CreateBarChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
 
 const carditisSummaryData = shallowRef<ICarditisSummaryRoot>()
+const carditisSummaryDataFromReports = shallowRef<ICarditisSummaryFromReportsRoot>()
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()
 const deathSummaryDataFromReports = shallowRef<IDeathSummaryFromReportsRoot>()
 onMounted(() => {
@@ -284,6 +306,24 @@ onMounted(() => {
       window.dispatchEvent(new Event('resize'))
     })
     .catch((error) => console.log('failed to get carditis summary data: ' + error))
+  
+  axios
+    .get<ICarditisSummaryFromReportsRoot>(CarditisSummaryFromReportsURL)
+    .then((response) => {
+      carditisSummaryDataFromReports.value = response.data
+
+      const top_ten_list = carditisSummaryDataFromReports.value.carditis_summary_from_reports.lot_no_info.top_ten_list
+      const lot_no_data = []
+      for (let index = 0; index < top_ten_list.length; index++) {
+        lot_no_data.push({x: top_ten_list[index].lot_no, y: top_ten_list[index].count})
+      }
+      lotNumberSeries.value = lot_no_data
+      lotNumberTopTenList.value = top_ten_list
+
+      // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
+      window.dispatchEvent(new Event('resize'))
+    })
+    .catch((error) => console.log('failed to get carditis summary from reports data: ' + error))
 
   axios
     .get<IDeathSummaryRoot>(DeathSummaryURL)
@@ -306,7 +346,7 @@ onMounted(() => {
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
     })
-    .catch((error) => console.log('failed to get carditis summary data: ' + error))
+    .catch((error) => console.log('failed to get death summary data: ' + error))
 
   axios
     .get<IDeathSummaryFromReportsRoot>(DeathSummaryFromReportsURL)
@@ -316,7 +356,7 @@ onMounted(() => {
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
     })
-    .catch((error) => console.log('failed to get carditis summary data: ' + error))
+    .catch((error) => console.log('failed to get death summary from reports data: ' + error))
 })
 
 const isPersentView = shallowRef(true)
@@ -606,6 +646,13 @@ const addNewLineWithBrackets = (label: string): string => {
     joined += '(' + split[index];
   }
   return joined
+}
+
+const lotNumberSeries = shallowRef<any[]>([])
+const lotNumberOptions = CreateBarChartOption('報告が多いロットNoの上位10種')
+const lotNumberTopTenList = shallowRef<ILotNumberItem[]>([])
+const createUrl = (value: string) => {
+  return '#/reported-myocarditis-issues?ln=' + value
 }
 </script>
 


### PR DESCRIPTION
## ページへのリンク

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/faa39093-afa0-411b-b0d9-1c4b52bc268e)

「参考情報」ページを新規追加。

## 注意事項

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/9cec5d87-c95a-45bd-8e8b-e2b67c5d4086)

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/b7949437-ea56-4db3-8c72-d3661405e3b7)

ページ冒頭に目立つように注意事項を配置。特に大事なポイントは大文字・太字でさらに強調。

## 数が多い上位10種をグラフ化

![image](https://github.com/vaccinesosjapan/dashboard/assets/147464913/a22a7003-2a61-4bd8-a718-0f1c5106f56a)

全体の中で数が多いものを表示するとファイザーばかりになる。モデルナも傾向をみるため別途グラフ化。

Close #25 