### PR TITLE
fix: 検索対象の文字列データがstring配列の場合にも、半角/全角を考慮せず小文字で検索するように変更

### DIFF
--- a/src/tools/FilterFunc.ts
+++ b/src/tools/FilterFunc.ts
@@ -21,7 +21,9 @@ export const StringArrayFilterFunc = (values: string[], filterVal: ShallowRef<st
   if(values.length == 0) return false
 
   for (let index = 0; index < values.length; index++) {
-    if(values[index].toLowerCase().indexOf(filterVal.value.toLowerCase()) > -1) return true
+    const targetVal = values[index].normalize('NFKC').toLowerCase()
+    const searchVal = filterVal.value.normalize('NFKC').toLowerCase()
+    if(targetVal.indexOf(searchVal) > -1) return true
   }
 
   return false


### PR DESCRIPTION
型が文字列配列のデータに対しても　#35 の改善が適用されるよう修正した。

Close #35