### PR TITLE
feat: 審議会の件数と認定比率のグラフを集計結果ページに追加

### DIFF
--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -33,3 +33,4 @@ export const CertifiedMetadataURL = DatasetsURL + 'certified-metadata.json'
 
 export const CertifiedSymptomsDataURL = DatasetsURL + 'certified-symptoms.json'
 export const CertifiedSymptomsMetadataURL = DatasetsURL + 'certified-symptoms-metadata.json'
+export const JudgedDataURL = DatasetsURL + 'judged-data.json'

--- a/src/tools/ChartOptions.ts
+++ b/src/tools/ChartOptions.ts
@@ -136,7 +136,7 @@ export const CreateEachCertifiedCountAndRateChartOption = (title: string, info: 
     },
     tooltip: {
     y: {
-        formatter: function(value: any, { series, seriesIndex, dataPointIndex, w }) {
+        formatter: function(value: any, { series, seriesIndex, dataPointIndex, w } :any) {
           if(w.config.series[seriesIndex].name == info.RateSeriesName){
             return (value as number).toFixed(1) + ' %'
           } else {

--- a/src/tools/ChartOptions.ts
+++ b/src/tools/ChartOptions.ts
@@ -95,3 +95,123 @@ export const CreateBarChartOption = (title: string): any =>{
     labels: []
   }
 }
+
+const xAxisTitleOfCertifiedCountAndRateChart = '審議会の開催日'
+
+export interface ICertifiedCountAndRateGraphInfo {
+  CountTitle: string
+  RateTitle: string
+  RepudiationSeriesName: string
+  CertifiedSeriesName: string
+  RateSeriesName: string
+}
+
+export const CreateEachCertifiedCountAndRateChartOption = (title: string, info: ICertifiedCountAndRateGraphInfo, labels: string[], countMax: number): any =>{
+  return {
+    chart: {
+      type: 'line',
+      stacked: true,
+      toolbar: {
+        export: {
+          csv: {
+            headerCategory: xAxisTitleOfCertifiedCountAndRateChart,
+            headerValue: 'value',
+            categoryFormatter(x: any) {
+              return new Date(x).toDateString()
+            }
+          }
+        }
+      }
+    },
+    stroke: {
+      width: 5
+    },
+    title: {
+      text: title,
+      style: {
+        fontSize: '1.2rem',
+        colors: ['#212121'],
+      },
+      offsetY: 20
+    },
+    tooltip: {
+    y: {
+        formatter: function(value: any, { series, seriesIndex, dataPointIndex, w }) {
+          if(w.config.series[seriesIndex].name == info.RateSeriesName){
+            return (value as number).toFixed(1) + ' %'
+          } else {
+            return (value as number).toLocaleString() + ' 件'
+          }
+        }
+      },
+    },
+    labels: labels,
+    xaxis: {
+      title: {
+        text: xAxisTitleOfCertifiedCountAndRateChart,
+        offsetY: -25,
+        style: {
+          fontSize: '1rem',
+          colors: ['#212121'],
+        },
+      }
+    },
+    yaxis: [
+      {
+        seriesName: [info.RepudiationSeriesName, info.CertifiedSeriesName],
+        labels: {
+          formatter: function (value: any) {
+            return value.toLocaleString()
+          },
+          style: {
+            colors: ['#E83938'],
+          }
+        },
+        max: countMax
+      },
+      {
+        seriesName: [info.RepudiationSeriesName, info.CertifiedSeriesName],
+        title: {
+          text: info.CountTitle,
+          style: {
+            fontSize: '1rem',
+            color: '#6CAF52',
+          },
+        },
+        labels: {
+          formatter: function (value: any) {
+            return value.toLocaleString()
+          },
+          style: {
+            colors: ['#6CAF52'],
+          }
+        },
+        max: countMax,
+      },
+      {
+        seriesName: info.RateSeriesName,
+        opposite: true,
+        title: {
+          text: info.RateTitle,
+          style: {
+            fontSize: '1rem',
+            color: '#7560CF',
+          },
+        },
+        max: 100.0,
+        labels: {
+          formatter: function (value: any) {
+            return value.toFixed(1)
+          },
+          style: {
+            colors: ['#7560CF'],
+          }
+        },
+      }
+    ],
+    colors: ['#E83938', '#6CAF52', '#7560CF'],
+    legend: {
+      fontSize: '14rem',
+    }
+  }
+}

--- a/src/types/JudgedData.ts
+++ b/src/types/JudgedData.ts
@@ -1,0 +1,10 @@
+// 審査結果の毎回の件数や累計の件数、認定の割合などのデータ
+export interface IJudgedData {
+	Date: string
+    CertifiedCount: number
+    RepudiationCount: number,
+    CertifiedRate: number,
+    CertifiedCountSum: number,
+    RepudiationCountSum: number,
+    CertifiedRateSum: number
+}


### PR DESCRIPTION
毎回の審議会の結果から、否認件数と認定件数を積み重ねた棒グラフと、各回の認定比率をグラフ化した。

![image](https://github.com/user-attachments/assets/e7580d4c-97dc-42ec-9d9d-eb3c3aff3e1a)

また審議会の累計の結果を用いて、同様のグラフ化を行った。

![image](https://github.com/user-attachments/assets/205811fd-1d89-433f-8bf2-1024d681a305)

Close #38 