### PR TITLE
年選択をUIを指でも操作しやすいものに変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "@mdi/font": "^7.3.67",
         "apexcharts": "^3.41.0",
         "axios": "^1.6.0",
+        "flatpickr": "^4.6.13",
         "pinia": "^2.1.6",
         "vue": "^3.4.21",
+        "vue-flatpickr-component": "^11.0.5",
         "vue-router": "^4.2.4",
         "vue3-apexcharts": "^1.4.4",
         "vuetify": "^3.3.21"
@@ -2385,6 +2387,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "license": "MIT"
+    },
     "node_modules/flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
@@ -4734,6 +4742,21 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-flatpickr-component": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/vue-flatpickr-component/-/vue-flatpickr-component-11.0.5.tgz",
+      "integrity": "sha512-Vfwg5uVU+sanKkkLzUGC5BUlWd5wlqAMq/UpQ6lI2BCZq0DDrXhOMX7hrevt8bEgglIq2QUv0K2Nl84Me/VnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "flatpickr": "^4.6.13"
+      },
+      "engines": {
+        "node": ">=14.13.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@mdi/font": "^7.3.67",
     "apexcharts": "^3.41.0",
     "axios": "^1.6.0",
+    "flatpickr": "^4.6.13",
     "pinia": "^2.1.6",
     "vue": "^3.4.21",
+    "vue-flatpickr-component": "^11.0.5",
     "vue-router": "^4.2.4",
     "vue3-apexcharts": "^1.4.4",
     "vuetify": "^3.3.21"

--- a/src/components/EvaluationResultHelpDialog.vue
+++ b/src/components/EvaluationResultHelpDialog.vue
@@ -1,7 +1,8 @@
 <template>
 	<v-dialog transition="dialog-bottom-transition" width="auto">
 		<template v-slot:activator="{ props }">
-			<v-btn prepend-icon="mdi-help-circle-outline" v-bind="props">評価記号について...</v-btn>
+			<v-btn class="text-body-2 mb-5" prepend-icon="mdi-help-circle-outline" 
+			v-bind="props" text="評価記号について..." color="blue-grey-lighten-4"></v-btn>
 		</template>
 
 		<template v-slot:default="{ isActive }">

--- a/src/components/FlatPickrWrapper.vue
+++ b/src/components/FlatPickrWrapper.vue
@@ -1,0 +1,59 @@
+<template>
+      <flat-pickr v-model="dateModel" placeholder="日付を選択.." :config="dateTimePickerConfig"></flat-pickr>
+</template>
+
+<script setup lang="ts">
+import flatPickr from 'vue-flatpickr-component'
+import 'flatpickr/dist/themes/material_green.css'
+import { Japanese as JapaneseLocale} from 'flatpickr/dist/l10n/ja.js'
+import YearSelectPlugin from '@/plugins/YearSelectPlugin';
+
+defineProps<{
+}>()
+
+const dateModel = defineModel<string>('date', { default: '' })
+
+// special thanks: http://cmz.wp.xdomain.jp/archives/1070
+const onDayCreate = ( dObj: any, dStr: any, fp: any, dayElem: any ) => {
+  var dayOfWeek = dayElem.dateObj.getDay();
+  switch( dayOfWeek ){
+    case 0: dayElem.classList.add('sunday'); break;
+    case 6: dayElem.classList.add('saturday'); break;
+  }
+}
+
+const dateTimePickerConfig :any = {
+	locale: JapaneseLocale,
+	altInput: true,
+	altFormat: "Y年m月d日",
+	dateFormat : 'Y-m-d',
+	disableMobile: true,
+	onDayCreate: onDayCreate,
+	plugins: [YearSelectPlugin({startYear: 2021, endYear: new Date().getFullYear(), yearUnit: '年', yearFirst: true})]
+}
+</script>
+
+<style>
+/* Copy from bootstrap */
+.form-control.input {
+    display: block;
+    height: calc(1.5em + .75rem + 2px);
+    width: 160px;
+    padding: .375rem .75rem;
+    font-size: 0.9rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    border-radius: .25rem;
+    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out
+}
+.flatpickr-day.saturday:not(.selected) {
+	color: rgb(0, 0, 255);
+}
+.flatpickr-day.sunday:not(.selected) {
+	color: rgb(255, 0, 0);
+}
+</style>

--- a/src/components/FlatpickrCalendar.vue
+++ b/src/components/FlatpickrCalendar.vue
@@ -8,13 +8,13 @@
   
   <v-sheet class="d-flex flex-wrap">
     <v-sheet name="pickr" class="d-flex flex-wrap mt-2">
-      <flat-pickr class="pickr-control" v-model="startDateModel" placeholder="日付を選択.." :config="dateTimePickerConfig"></flat-pickr>
+      <FlatPickrWrapper v-model:date="startDateModel" ></FlatPickrWrapper>
     </v-sheet>
 
     <v-label class="ml-1 mr-2 mt-2 text-body-2">から</v-label>
 
     <v-sheet name="pickr" class="d-flex flex-wrap mt-2">
-      <flat-pickr class="pickr-control" v-model="endDateModel" placeholder="日付を選択.." :config="dateTimePickerConfig"></flat-pickr>
+      <FlatPickrWrapper v-model:date="endDateModel" ></FlatPickrWrapper>
     </v-sheet>
 
     <v-label class="ms-1 mt-2 text-body-2">までの期間を表示</v-label>
@@ -22,9 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import flatPickr from 'vue-flatpickr-component'
-import 'flatpickr/dist/themes/material_green.css'
-import { Japanese as JapaneseLocale} from 'flatpickr/dist/l10n/ja.js'
+import FlatPickrWrapper from '@/components/FlatPickrWrapper.vue'
 
 defineProps<{
   title: string
@@ -33,66 +31,14 @@ defineProps<{
 const startDateModel = defineModel<string>('start', { default: '' })
 const endDateModel = defineModel<string>('end', { default: '' })
 
-// special thanks: http://cmz.wp.xdomain.jp/archives/1070
-const onDayCreate = ( dObj: any, dStr: any, fp: any, dayElem: any ) => {
-  var dayOfWeek = dayElem.dateObj.getDay();
-  switch( dayOfWeek ){
-    case 0: dayElem.classList.add('sunday'); break;
-    case 6: dayElem.classList.add('saturday'); break;
-  }
-}
-/*const onChange = (selectedDates: any, dateStr: string, instance: any) => {
-  console.log(dateStr)
-}*/
-
-const dateTimePickerConfig = {
-	locale: JapaneseLocale,
-  altInput: true,
-  altFormat: "Y年m月d日",
-	dateFormat : 'Y-m-d',
-  disableMobile: true,
-	onDayCreate: onDayCreate,
-  //onChange: onChange
-}
-
-const onClear = (event: Event) => {
-  const parentOfPickrElem = (event.target as HTMLButtonElement).parentElement?.parentElement?.nextElementSibling
-  if(!parentOfPickrElem?.hasChildNodes) return
-  for (const childNode of parentOfPickrElem.children) {
-    if(childNode.getAttribute('name') == 'pickr'){
-      (childNode.firstChild as any)._flatpickr.clear()
-    } 
-  }
+const onClear = () => {
+  startDateModel.value = ''
+  endDateModel.value = ''
 }
 </script>
 
 <style scoped>
 .small-text {
   font-size: 0.7rem;
-}
-</style>
-
-<style>
-/* Copy from bootstrap */
-.form-control.input {
-    display: block;
-    height: calc(1.5em + .75rem + 2px);
-    width: 160px;
-    padding: .375rem .75rem;
-    font-size: 0.9rem;
-    font-weight: 400;
-    line-height: 1.5;
-    color: #495057;
-    background-color: #fff;
-    background-clip: padding-box;
-    border: 1px solid #ced4da;
-    border-radius: .25rem;
-    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out
-}
-.flatpickr-day.saturday:not(.selected) {
-	color: rgb(0, 0, 255);
-}
-.flatpickr-day.sunday:not(.selected) {
-	color: rgb(255, 0, 0);
 }
 </style>

--- a/src/components/FlatpickrCalendar.vue
+++ b/src/components/FlatpickrCalendar.vue
@@ -1,0 +1,98 @@
+<template>
+  <v-sheet class="d-flex flex-wrap">
+    <h7 class="mt-2 text-h7">{{ title }}</h7>
+    <v-btn v-if="(startDateModel != '' && startDateModel != undefined) || (endDateModel != '' && endDateModel != undefined)"
+     class="ml-auto mt-2 small-text" prepend-icon="mdi-backspace-outline"
+     :onclick="onClear" size="small" density="comfortable" variant="elevated" color="lime-lighten-1" text="入力した日付を消去"></v-btn>
+  </v-sheet>
+  
+  <v-sheet class="d-flex flex-wrap">
+    <v-sheet name="pickr" class="d-flex flex-wrap mt-2">
+      <flat-pickr class="pickr-control" v-model="startDateModel" placeholder="日付を選択.." :config="dateTimePickerConfig"></flat-pickr>
+    </v-sheet>
+
+    <v-label class="ml-1 mr-2 mt-2 text-body-2">から</v-label>
+
+    <v-sheet name="pickr" class="d-flex flex-wrap mt-2">
+      <flat-pickr class="pickr-control" v-model="endDateModel" placeholder="日付を選択.." :config="dateTimePickerConfig"></flat-pickr>
+    </v-sheet>
+
+    <v-label class="ms-1 mt-2 text-body-2">までの期間を表示</v-label>
+  </v-sheet>
+</template>
+
+<script setup lang="ts">
+import flatPickr from 'vue-flatpickr-component'
+import 'flatpickr/dist/themes/material_green.css'
+import { Japanese as JapaneseLocale} from 'flatpickr/dist/l10n/ja.js'
+
+defineProps<{
+  title: string
+}>()
+
+const startDateModel = defineModel<string>('start', { default: '' })
+const endDateModel = defineModel<string>('end', { default: '' })
+
+// special thanks: http://cmz.wp.xdomain.jp/archives/1070
+const onDayCreate = ( dObj: any, dStr: any, fp: any, dayElem: any ) => {
+  var dayOfWeek = dayElem.dateObj.getDay();
+  switch( dayOfWeek ){
+    case 0: dayElem.classList.add('sunday'); break;
+    case 6: dayElem.classList.add('saturday'); break;
+  }
+}
+/*const onChange = (selectedDates: any, dateStr: string, instance: any) => {
+  console.log(dateStr)
+}*/
+
+const dateTimePickerConfig = {
+	locale: JapaneseLocale,
+  altInput: true,
+  altFormat: "Y年m月d日",
+	dateFormat : 'Y-m-d',
+  disableMobile: true,
+	onDayCreate: onDayCreate,
+  //onChange: onChange
+}
+
+const onClear = (event: Event) => {
+  const parentOfPickrElem = (event.target as HTMLButtonElement).parentElement?.parentElement?.nextElementSibling
+  if(!parentOfPickrElem?.hasChildNodes) return
+  for (const childNode of parentOfPickrElem.children) {
+    if(childNode.getAttribute('name') == 'pickr'){
+      (childNode.firstChild as any)._flatpickr.clear()
+    } 
+  }
+}
+</script>
+
+<style scoped>
+.small-text {
+  font-size: 0.7rem;
+}
+</style>
+
+<style>
+/* Copy from bootstrap */
+.form-control.input {
+    display: block;
+    height: calc(1.5em + .75rem + 2px);
+    width: 160px;
+    padding: .375rem .75rem;
+    font-size: 0.9rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    border-radius: .25rem;
+    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out
+}
+.flatpickr-day.saturday:not(.selected) {
+	color: rgb(0, 0, 255);
+}
+.flatpickr-day.sunday:not(.selected) {
+	color: rgb(255, 0, 0);
+}
+</style>

--- a/src/components/NumberFilter.vue
+++ b/src/components/NumberFilter.vue
@@ -1,36 +1,23 @@
 <template>
-	<v-card
-		:subtitle="title"
-		variant="flat"
-	>
-		<v-row justify="center">
-			<v-col cols="5">
-				<v-text-field
-				label="最小"
-				v-model="minVal"
-				type="number"
-				@input="searchTrigerFunc"
-				@click:clear="clearTriggerFunc"
-				clearable
-				hide-details
-				></v-text-field>
-			</v-col>
+	<v-sheet class="d-flex flex-wrap">
+		<h7 class="mt-2 text-h7">{{ title }}</h7>
+	</v-sheet>
 
-			<v-col cols="auto" class="d-flex align-center">～</v-col>
+	<v-sheet class="d-flex flex-wrap">
+		<v-responsive max-width="110">
+			<v-text-field label="最小" v-model="minVal" type="number"
+				@input="searchTrigerFunc" @click:clear="clearTriggerFunc" hide-details></v-text-field>
+		</v-responsive>
 
-			<v-col cols="5">
-				<v-text-field
-				label="最大"
-				v-model="maxVal"
-				type="number"
-				@input="searchTrigerFunc"
-				@click:clear="clearTriggerFunc"
-				clearable
-				hide-details
-				></v-text-field>
-			</v-col>
-		</v-row>
-	</v-card>
+		<v-label class="ml-1 mr-2 mt-2 text-body-2">から</v-label>
+
+		<v-responsive max-width="110">
+			<v-text-field label="最大" v-model="maxVal" type="number"
+				@input="searchTrigerFunc" @click:clear="clearTriggerFunc" hide-details></v-text-field>
+		</v-responsive>
+
+		<v-label class="ml-1 mt-2 text-body-2">まで</v-label>
+	</v-sheet>
 </template>
 
 <script setup lang="ts">

--- a/src/plugins/yearSelectPlugin.ts
+++ b/src/plugins/yearSelectPlugin.ts
@@ -1,0 +1,85 @@
+// This plugin based on the flatpickr-year-select-plugin.
+// To apply custom theme properly, I made this code.
+//  https://github.com/bearholmes/flatpickr-year-select-plugin
+
+export interface YearSelectPluginConfig {
+  startYear?: number
+  endYear?: number
+  yearUnit?: string
+  yearFirst?: boolean
+}
+
+const YearSelectPlugin = function (config: YearSelectPluginConfig) {
+  const yearSelectElem = document.createElement("select")
+  yearSelectElem.classList.add("flatpickr-monthDropdown-months")
+
+  const currentYear = new Date().getFullYear()
+  if(config.startYear === undefined)
+    config.startYear = currentYear - 3
+  if(config.endYear === undefined)
+    config.endYear = currentYear + 3
+
+  for (let i = config.startYear; i <= config.endYear; i++) {
+    const optionElem = document.createElement("option")
+    optionElem.setAttribute('class', 'flatpickr-monthDropdown-month')
+    optionElem.value = String(i)
+    if(config.yearUnit !== undefined)
+      optionElem.text = String(`${i}${config.yearUnit}`)
+    else
+      optionElem.text = String(`${i}`)
+    yearSelectElem.appendChild(optionElem)
+  }
+  yearSelectElem.value = String(config.startYear)
+
+  return function (fp: any) {
+    if (!fp) return;
+
+    yearSelectElem.addEventListener("change", function (evt) {
+      const target = evt.target as HTMLSelectElement
+      if (!target) return
+      const year = target.options[target.selectedIndex].value
+
+      fp.changeYear(Number(year))
+      fp.redraw()
+    })
+   
+    fp.yearSelectElem = yearSelectElem
+
+    return {
+      onReady: function onReady() {
+        const collection = fp.calendarContainer.getElementsByClassName('flatpickr-current-month')
+        if (collection.length == 0) return
+
+        const currentMonthElem = collection[0]
+        const monthSelectElem = currentMonthElem.childNodes[0]
+        const originalYearInputElem = currentMonthElem.childNodes[1]
+
+        if(config.yearFirst !== undefined && config.yearFirst)
+          currentMonthElem.insertBefore(fp.yearSelectElem, monthSelectElem)
+        else
+          currentMonthElem.insertBefore(fp.yearSelectElem, originalYearInputElem)
+
+        originalYearInputElem.style.display = 'none'
+
+        if (!fp.config.minDate) fp.set("minDate", `${config.startYear}-01-01`)
+        if (!fp.config.maxDate) fp.set("maxDate", `${config.endYear}-12-31`)
+      },
+      onOpen: function onOpen(
+        _selectedDates: any,
+        _dateStr: any,
+        instance: { currentYear: any }
+      ) {
+        yearSelectElem.value = String(instance.currentYear)
+      },
+      onYearChange: function onYearChange(
+        _selectedDates: any,
+        _dateStr: any,
+        instance: { currentYear: any }
+      ) {
+        yearSelectElem.value = String(instance.currentYear)
+      },
+    };
+  };
+};
+
+export default YearSelectPlugin

--- a/src/views/MyocarditisView.vue
+++ b/src/views/MyocarditisView.vue
@@ -9,7 +9,7 @@
       </v-expansion-panel-title>
 
       <v-expansion-panel-text>
-        <h6 class="text-h6">ワクチンに関する条件の設定</h6>
+        <h6 class="text-h6 mb-2 underline">ワクチンに関する条件の設定</h6>
         <v-row align="end">
           <v-col v-for="item, i in vaccineSearchItems" :key="i" cols="12" :md="item.md">
             <v-text-field
@@ -25,9 +25,9 @@
         </v-row>
 
         <br />
-        <h6 class="text-h6">個人に関する条件の設定</h6>
+        <h6 class="text-h6 mb-2 underline">個人に関する条件の設定</h6>
         <v-row align="end">
-          <v-col v-for="item, i in individualSearchItems" :key="i" cols="12" :md="item.md" class="group">
+          <v-col v-for="item, i in individualSearchItems" :key="i" cols="12" :md="item.md" class="group mt-1">
 
             <NumberFilter v-if="item.type == 'age'"
             v-model:min="ageFromFilterVal" v-model:max="ageToFilterVal"
@@ -40,10 +40,8 @@
             :label="item.label"
             ></SelectItems>
 
-            <DateFilter v-else-if="item.type == 'vaccinated_date'"
-              v-model:start="vaccinatedDateFromFilterVal" v-model:end="vaccinatedDateToFilterVal"
-              :title="item.label" :search-triger-func="searchTrigerFunc" :clear-trigger-func="clearTriggerFunc"
-            ></DateFilter>
+            <FlatpickrCalendar v-else-if="item.type == 'vaccinated_date'"
+             :title="item.label" v-model:start="vaccinatedDateFromFilterVal" v-model:end="vaccinatedDateToFilterVal"></FlatpickrCalendar>
 
             <NumberFilter v-else-if="item.type == 'days_to_onset'"
             v-model:min="daysToOnsetFromFilterVal" v-model:max="daysToOnsetToFilterVal"
@@ -55,10 +53,8 @@
             :title="item.label" :search-triger-func="searchTrigerFunc" :clear-trigger-func="clearTriggerFunc"
             ></NumberFilter>
 
-            <DateFilter v-else-if="item.type == 'gross_result_date'"
-              v-model:start="grossResultDateFromFilterVal" v-model:end="grossResultDateToFilterVal"
-              :title="item.label" :search-triger-func="searchTrigerFunc" :clear-trigger-func="clearTriggerFunc"
-            ></DateFilter>
+            <FlatpickrCalendar v-else-if="item.type == 'gross_result_date'"
+             :title="item.label" v-model:start="grossResultDateFromFilterVal" v-model:end="grossResultDateToFilterVal"></FlatpickrCalendar>
 
             <v-text-field v-else
               :label="item.label"
@@ -73,7 +69,7 @@
         </v-row>
 
         <v-row align="end">
-          <v-col cols="12" md="2" class="group">
+          <v-col cols="12" md="4" class="group">
             <SelectItems
             v-model:values="causalRelFilterValues" v-model:items="causalRelFilterItems"
             :search-triger-func="searchTrigerFunc" :clear-trigger-func="clearTriggerFunc"
@@ -81,7 +77,7 @@
             ></SelectItems>
           </v-col>
 
-          <v-col cols="12" md="2" class="group">
+          <v-col cols="12" md="4" class="group">
             <EvaluationResultHelpDialog></EvaluationResultHelpDialog>
           </v-col>
         </v-row>
@@ -192,6 +188,7 @@ import DateFilter from '@/components/DateFilter.vue'
 import SelectItems from '@/components/SelectItems.vue'
 import SearchRelatedToolBar from '@/components/SearchRelatedToolBar.vue'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
+import FlatpickrCalendar from '@/components/FlatpickrCalendar.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
@@ -456,5 +453,11 @@ const clearFilter = () => {
 .search-title {
   font-size: 1.5rem;
   padding-left: 0.8rem;
+}
+.underline{
+  text-underline-offset: 0.2rem;
+  text-decoration-line: underline;
+  text-decoration-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
+  text-decoration-thickness: 1.2px;
 }
 </style>


### PR DESCRIPTION
カレンダーの年を編集するUIが、スマホ画面などで指による操作をする際に小さすぎて編集しづらかった。
そのため、flatpickrの年選択を変更するプラグインを開発し、下図のように変更した。

![image](https://github.com/user-attachments/assets/9a67a783-a751-457f-9d06-84b02ee21568)
