### PR TITLE
製造販売業者別の集計を追加し、グラフに用いたデータの母数を明記する

### DIFF
--- a/src/components/CarditisPerAgeGraph.vue
+++ b/src/components/CarditisPerAgeGraph.vue
@@ -20,7 +20,7 @@ defineProps<{
 const mediumChartOption = shallowRef<any>()
 const mChartOp = createBaseChartOption()
 mChartOp.dataLabels.style = {
-	fontSize: '0.9rem',
+	fontSize: '1rem',
 	colors: ['#818181'],
 }
 mChartOp.dataLabels.background = {
@@ -55,7 +55,7 @@ const issueFormatter = (value: any) => { return value.toLocaleString() + ' 人' 
 const createBaseChartOption = (): any =>{
   return {
     title: {
-      text: '心筋炎/心膜炎になった方々の人数（年代別）',
+      text: '心筋炎/心膜炎の方々の人数（年代別）',
 	    floating: true
     },
     chart: {

--- a/src/components/CarditisPerAgeGraph.vue
+++ b/src/components/CarditisPerAgeGraph.vue
@@ -1,0 +1,121 @@
+<template>
+
+  <v-sheet class="d-block d-md-none">
+    <apexchart height="400" :options="shortChartOption" :series="[{data: series}]"></apexchart>
+  </v-sheet>
+
+  <v-sheet class="d-none d-md-block">
+    <apexchart height="400" :options="mediumChartOption" :series="[{data: series}]"></apexchart>
+  </v-sheet>
+
+</template>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue';
+
+defineProps<{
+  series: {x: string, y: number}[]
+}>()
+
+const mediumChartOption = shallowRef<any>()
+const mChartOp = createBaseChartOption()
+mChartOp.dataLabels.style = {
+	fontSize: '0.9rem',
+	colors: ['#818181'],
+}
+mChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+mChartOp.dataLabels.offsetX = 35
+mChartOp.dataLabels.offsetY = 6
+mediumChartOption.value = mChartOp
+
+const shortChartOption = shallowRef<any>()
+const sChartOp = createBaseChartOption()
+sChartOp.dataLabels.style = {
+	fontSize: '0.9rem',
+	colors: ['#818181'],
+}
+sChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+sChartOp.dataLabels.offsetX = 35
+sChartOp.dataLabels.offsetY = 6
+sChartOp.xaxis.tickAmount = 3
+shortChartOption.value = sChartOp
+</script>
+
+<script lang="ts">
+const downloadFileName = 'carditis-per-age-graph'
+
+const numberFormatter = (value: any) => { return value.toLocaleString() }
+const issueFormatter = (value: any) => { return value.toLocaleString() + ' 人' }
+const createBaseChartOption = (): any =>{
+  return {
+    title: {
+      text: '心筋炎/心膜炎になった方々の人数（年代別）',
+	    floating: true
+    },
+    chart: {
+      type: 'bar',
+	    toolbar:{
+        export: {
+          csv: {
+            filename: downloadFileName,
+          },
+          svg: {
+            filename: downloadFileName,
+          },
+          png: {
+            filename: downloadFileName,
+          }
+        },
+      }
+    },
+	  colors: ['#c83f3d'],
+    xaxis: {
+      title: {
+        text: '人数'
+      },
+      labels: {
+        formatter: numberFormatter
+      },
+    },
+    yaxis: {
+      title: {
+        text: '年代'
+      },
+      labels: {
+        style: {
+          fontSize: '0.8rem'
+        },
+        offsetY: 5,
+        maxWidth: 250
+      }
+    },
+    tooltip: {
+      y: {
+        formatter: issueFormatter,
+        title: {
+			    formatter: (): string => {
+				    return `人数: `
+			    }
+		    }
+      },
+    },
+    plotOptions: {
+      bar: {
+        horizontal: true,
+		    borderRadius: 2
+      },
+    },
+    dataLabels: {
+      formatter: issueFormatter
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -175,7 +175,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
       offsetY: 20
     },
     tooltip: {
-    y: {
+      y: {
         formatter: function(value: any, { series, seriesIndex, dataPointIndex, w } :any) {
           if(w.config.series[seriesIndex].name == info.RateSeriesName){
             return (value as number).toFixed(1) + ' %'

--- a/src/components/DeathPerAgeGraph.vue
+++ b/src/components/DeathPerAgeGraph.vue
@@ -20,7 +20,7 @@ defineProps<{
 const mediumChartOption = shallowRef<any>()
 const mChartOp = createBaseChartOption()
 mChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 mChartOp.dataLabels.background = {
@@ -34,7 +34,7 @@ mediumChartOption.value = mChartOp
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption()
 sChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 sChartOp.dataLabels.background = {
@@ -56,37 +56,37 @@ const createBaseChartOption = (): any =>{
   return {
     title: {
       text: '亡くなられた方々の人数（年代別）',
-	  floating: true
+	    floating: true
     },
     chart: {
       type: 'bar',
-	  toolbar:{
-		export: {
-			csv: {
-				filename: downloadFileName,
-			},
-			svg: {
-				filename: downloadFileName,
-			},
-			png: {
-				filename: downloadFileName,
-			}
-		},
+      toolbar:{
+        export: {
+          csv: {
+            filename: downloadFileName,
+          },
+          svg: {
+            filename: downloadFileName,
+          },
+          png: {
+            filename: downloadFileName,
+          }
+        },
       }
     },
-	colors: ['#c83f3d'],
+	  colors: ['#c83f3d'],
     xaxis: {
       title: {
         text: '人数'
       },
-	  labels: {
-		formatter: numberFormatter
-	  },
+	    labels: {
+        formatter: numberFormatter
+      },
     },
     yaxis: {
-	  title: {
-		text: '年代'
-	  },
+      title: {
+        text: '年代'
+      },
       labels: {
         style: {
           fontSize: '0.8rem'
@@ -99,16 +99,16 @@ const createBaseChartOption = (): any =>{
       y: {
         formatter: issueFormatter,
         title: {
-			formatter: (): string => {
-				return `人数: `
-			}
-		}
+          formatter: (): string => {
+            return `人数: `
+          }
+        }
       },
     },
     plotOptions: {
       bar: {
         horizontal: true,
-		borderRadius: 2
+		    borderRadius: 2
       },
     },
     dataLabels: {

--- a/src/components/DeathPerAgeGraph.vue
+++ b/src/components/DeathPerAgeGraph.vue
@@ -20,7 +20,7 @@ defineProps<{
 const mediumChartOption = shallowRef<any>()
 const mChartOp = createBaseChartOption()
 mChartOp.dataLabels.style = {
-	fontSize: '0.9rem',
+	fontSize: '1rem',
 	colors: ['#818181'],
 }
 mChartOp.dataLabels.background = {

--- a/src/components/HorizontalBarGraph.vue
+++ b/src/components/HorizontalBarGraph.vue
@@ -21,7 +21,18 @@ const props = defineProps<{
 }>()
 
 const mediumChartOption = shallowRef<any>()
-mediumChartOption.value = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
+const mChartOp = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
+mChartOp.dataLabels.style = {
+	fontSize: '1rem',
+	colors: ['#818181'],
+}
+mChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+mChartOp.dataLabels.offsetX = 35
+mChartOp.dataLabels.offsetY = 6
+mediumChartOption.value = mChartOp
 
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)

--- a/src/components/HorizontalBarGraph.vue
+++ b/src/components/HorizontalBarGraph.vue
@@ -26,7 +26,7 @@ mediumChartOption.value = createBaseChartOption(props.graphTitle, props.xAxisTit
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
 sChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 sChartOp.dataLabels.background = {
@@ -51,18 +51,18 @@ const createBaseChartOption = (graphTitle: string[], xAxisTitle: string, downloa
     },
     chart: {
       type: 'bar',
-	  toolbar:{
-		export: {
-			csv: {
-				filename: downloadFileName,
-			},
-			svg: {
-				filename: downloadFileName,
-			},
-			png: {
-				filename: downloadFileName,
-			}
-		},
+      toolbar:{
+        export: {
+          csv: {
+            filename: downloadFileName,
+          },
+          svg: {
+            filename: downloadFileName,
+          },
+          png: {
+            filename: downloadFileName,
+          }
+        },
       }
     },
     xaxis: {
@@ -70,7 +70,7 @@ const createBaseChartOption = (graphTitle: string[], xAxisTitle: string, downloa
         text: xAxisTitle
       },
 	  labels: {
-		formatter: numberFormatter
+		  formatter: numberFormatter
 	  },
     },
     yaxis: {

--- a/src/components/JudgedTrendsGraph.vue
+++ b/src/components/JudgedTrendsGraph.vue
@@ -74,7 +74,7 @@ mediumChartOption.value = createBaseChartOption(props.title)
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.title)
 sChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 sChartOp.dataLabels.background = {

--- a/src/components/JudgedTrendsGraph.vue
+++ b/src/components/JudgedTrendsGraph.vue
@@ -69,7 +69,18 @@ const createBaseChartOption = (title: string): any =>{
 }
 
 const mediumChartOption = shallowRef<any>()
-mediumChartOption.value = createBaseChartOption(props.title)
+const mChartOp = createBaseChartOption(props.title)
+mChartOp.dataLabels.style = {
+	fontSize: '1rem',
+	colors: ['#818181'],
+}
+mChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+mChartOp.dataLabels.offsetX = 35
+mChartOp.dataLabels.offsetY = 6
+mediumChartOption.value = mChartOp
 
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.title)

--- a/src/components/OtherVaccinesGraph.vue
+++ b/src/components/OtherVaccinesGraph.vue
@@ -58,7 +58,7 @@ const medicalChartOption = CreateEachBillingDetailsChartOption([`${headerNames[0
 const disabilityOfChildrenChartOption = CreateEachBillingDetailsChartOption([`${headerNames[1]} の認定件数まとめ`], '#54E496', categories, false)
 const disabilityChartOption = CreateEachBillingDetailsChartOption([`${headerNames[2]} の認定件数まとめ`], '#F6AD21', categories, false)
 const header4Array = headerNames[3].split('・')
-const deathChartOption = CreateEachBillingDetailsChartOption([`${header4Array.slice(0,2)}`,`${header4Array.slice(2,4)} の認定件数まとめ`], '#F23B61', categories, false)
+const deathChartOption = CreateEachBillingDetailsChartOption([`${header4Array.slice(0,2).join('、')}`,`${header4Array.slice(2,4).join('、')} の認定件数まとめ`], '#F23B61', categories, false)
 
 const updateFuncAll = (chart: any) => {
   if(allChartInstance.value !== undefined) return ''

--- a/src/types/CarditisSummary.ts
+++ b/src/types/CarditisSummary.ts
@@ -5,7 +5,8 @@ export interface ICarditisSummaryRoot {
 	carditis_issues: {
 		date: string
 		issues_with_vaccine_name: ICarditisIssueWithVaccineName[]
-		issues_by_manufacturers: ICarditisIssueWithManufacturer[]
+		issues_m_by_manufacturers: ICarditisIssueWithManufacturer[]
+		issues_p_by_manufacturers: ICarditisIssueWithManufacturer[]
 		issues_by_ages: {
 			ages_count: number
 			unknown_ages_count: number
@@ -30,6 +31,5 @@ export interface ICarditisIssueWithVaccineName {
 
 export interface ICarditisIssueWithManufacturer {
 	manufacturer: string
-	myocarditis_count: number
-	pericarditis_count: number
+	count: number
 }

--- a/src/types/CarditisSummary.ts
+++ b/src/types/CarditisSummary.ts
@@ -9,7 +9,7 @@ export interface ICarditisSummaryRoot {
 		issues_by_ages: {
 			ages_count: number
 			unknown_ages_count: number
-			issues: {age: string, count:number}[]
+			issues: {x:string, y:number}[]
 		}
 	}
 }
@@ -32,13 +32,4 @@ export interface ICarditisIssueWithManufacturer {
 	manufacturer: string
 	myocarditis_count: number
 	pericarditis_count: number
-}
-
-export const ConvertCarditisIssuesByAgesTo2dData = (issues: {age: string, count:number}[]): {x:string, y:number}[] => {
-	const data : {x:string, y:number}[] = []
-	for (let index = 0; index < issues.length; index++) {
-		const issue = issues[index];
-		data.push({x: issue.age, y: issue.count})
-	}
-	return data
 }

--- a/src/types/CarditisSummary.ts
+++ b/src/types/CarditisSummary.ts
@@ -4,7 +4,13 @@ export interface ICarditisSummaryRoot {
 	carditis_summary: ICarditisSummary
 	carditis_issues: {
 		date: string
-		issues_with_vaccine_name: ICarditisIssue[]
+		issues_with_vaccine_name: ICarditisIssueWithVaccineName[]
+		issues_by_manufacturers: ICarditisIssueWithManufacturer[]
+		issues_by_ages: {
+			ages_count: number
+			unknown_ages_count: number
+			issues: {age: string, count:number}[]
+		}
 	}
 }
 
@@ -16,8 +22,23 @@ export interface ICarditisSummary {
 	source: ISourceInfo
 }
 
-export interface ICarditisIssue {
+export interface ICarditisIssueWithVaccineName {
 	vaccine_name: string
 	myocarditis_count: number
 	pericarditis_count: number
+}
+
+export interface ICarditisIssueWithManufacturer {
+	manufacturer: string
+	myocarditis_count: number
+	pericarditis_count: number
+}
+
+export const ConvertCarditisIssuesByAgesTo2dData = (issues: {age: string, count:number}[]): {x:string, y:number}[] => {
+	const data : {x:string, y:number}[] = []
+	for (let index = 0; index < issues.length; index++) {
+		const issue = issues[index];
+		data.push({x: issue.age, y: issue.count})
+	}
+	return data
 }

--- a/src/types/DeathSummary.ts
+++ b/src/types/DeathSummary.ts
@@ -10,6 +10,7 @@ export interface IDeathSummary {
 	source: ISourceInfo
 	sum_by_evaluation: ISumByEvaluation
 	sum_by_vaccine_name: ISumByVaccineName[]
+	sum_by_manufacturer: ISumByManufacturer[]
 }
 
 export interface ISumByEvaluation {
@@ -28,6 +29,11 @@ export interface IEvaluations {
 	alpha: number
 	beta: number
 	gamma: number
+}
+
+export interface ISumByManufacturer {
+	manufacturer: string
+	death_count: number
 }
 
 export interface IDeathIssues {

--- a/src/types/DeathSummaryFromReports.ts
+++ b/src/types/DeathSummaryFromReports.ts
@@ -6,6 +6,8 @@ export interface IDeathSummaryFromReportsRoot {
 
 export interface IDeathSummaryFromReports {
 	date: string
+	ages_count: number
+	unknown_ages_count: number
 	sum_by_age: I2DItem[]
 	lot_no_info: ILotNumberInformation
 }

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -52,72 +52,26 @@
         </v-col>
       </v-row>
 
-      <CustomHeader2 title="心筋炎の件数内訳"></CustomHeader2>
-      <div class="d-flex justify-end">
-        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
-        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
+      <div class="text-body-1">
+        心筋炎の報告 {{ carditisSummaryData.carditis_summary.myocarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
       </div>
-      <v-row class="mb-2">
-        <v-col cols="12" md="8">
-          <apexchart :options="myocarditisByVaccineOptions" :series="myocarditisByVaccineSeries"></apexchart>
-        </v-col>
+      <HorizontalBarGraph :graph-title="['心筋炎の報告件数（製造販売業者別）']"
+          x-axis-title="報告件数" download-file-name="myocarditis-count-by-manufacturer" :series="myocarditisSeries"></HorizontalBarGraph>
 
-        <v-col  cols="12" md="4">
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-left">心筋炎件数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="label, index in myocarditisByVaccineLabels" :key="label">
-                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
-                <td class="text-right">{{ myocarditisByVaccineSeries[index].toLocaleString() }}</td>
-              </tr>
-              <tr>
-                <td><b>合計</b></td>
-                <td class="text-right text-body-2"><b>{{ myocarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
-              </tr>
-            </tbody>
-          </v-table>
-        </v-col>
-      </v-row>
-
-      <CustomHeader2 title="心膜炎の件数内訳"></CustomHeader2>
-      <div class="d-flex justify-end">
-        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
-        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      <div class="text-body-1 mt-2">
+        心膜炎の報告 {{ carditisSummaryData.carditis_summary.pericarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
       </div>
-      <v-row>
-        <v-col cols="12" md="8">
-          <apexchart :options="pericarditisByVaccineOptions" :series="pericarditisByVaccineSeries"></apexchart>
-        </v-col>
+      <HorizontalBarGraph :graph-title="['心膜炎の報告件数（製造販売業者別）']"
+          x-axis-title="報告件数" download-file-name="pericarditis-count-by-manufacturer" :series="pericarditisSeries"></HorizontalBarGraph>
 
-        <v-col  cols="12" md="4">
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-left">心膜炎件数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="label, index in pericarditisByVaccineLabels" :key="label">
-                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
-                <td class="text-right">{{ pericarditisByVaccineSeries[index].toLocaleString() }}</td>
-              </tr>
-              <tr>
-                <td><b>合計</b></td>
-                <td class="text-right"><b>{{ pericarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
-              </tr>
-            </tbody>
-          </v-table>
-        </v-col>
-      </v-row>
+      <CustomHeader2 title="年代別の集計"></CustomHeader2>
+      <div class="text-body-1 mb-2">
+        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnkownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ carditisAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ carditisUnkownAgesCount.toLocaleString() }} 件は年代不明）
+      </div>
+      <CarditisPerAgeGraph :series="carditisSummaryByAges"></CarditisPerAgeGraph>
+      <p class="text-caption text-right mt-1">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」が発表した資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
 
-      <p class="text-caption text-right mt-2">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」で
-      発表された資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
     <v-container v-if="deathSummaryData == undefined">
@@ -175,11 +129,13 @@
           </v-table>
           <EvaluationResultHelpDialog></EvaluationResultHelpDialog>
         </v-col>
+      </v-row>
 
+      <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
+      <v-row>
         <v-col cols="12" sm="8">
           <apexchart :options="deathSummaryByVaccineOptions" :series="deathSummaryByVaccineSeries"></apexchart>
         </v-col>
-
         <v-col  cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
@@ -213,8 +169,7 @@
     </v-container>
 
     <v-container v-else>
-      <CustomHeader2 title="年代別の内訳"></CustomHeader2>
-
+      <CustomHeader2 title="年代別の集計"></CustomHeader2>
       <v-row>
         <v-col cols="12">
           <DeathPerAgeGraph :series="deathSummaryDataFromReports.death_summary_from_reports.sum_by_age"></DeathPerAgeGraph>
@@ -233,12 +188,14 @@ import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
-import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
+import { ConvertCarditisIssuesByAgesTo2dData, type ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
 import CustomHeader1 from '@/components/CustomHeader1.vue'
 import CustomHeader2 from '@/components/CustomHeader2.vue'
+import HorizontalBarGraph from '@/components/HorizontalBarGraph.vue'
+import CarditisPerAgeGraph from '@/components/CarditisPerAgeGraph.vue'
 import DeathPerAgeGraph from '@/components/DeathPerAgeGraph.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
@@ -247,6 +204,11 @@ AppBarUseHelpPage.value = true
 AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const carditisSummaryData = shallowRef<ICarditisSummaryRoot>()
+const myocarditisSeries = shallowRef<{x: string, y: number}[]>([])
+const pericarditisSeries = shallowRef<{x: string, y: number}[]>([])
+const carditisSummaryByAges = shallowRef<{x:string, y:number}[]>([])
+const carditisAgesCount = shallowRef<number>(0)
+const carditisUnkownAgesCount = shallowRef<number>(0)
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()
 const deathSummaryDataFromReports = shallowRef<IDeathSummaryFromReportsRoot>()
 onMounted(() => {
@@ -267,6 +229,21 @@ onMounted(() => {
         pericarditisByVaccineLabels.value.push(issue.vaccine_name)
         pericarditisByVaccineSeries.value.push(issue.pericarditis_count)
       }
+
+      const issuesByM = carditisSummaryData.value.carditis_issues.issues_by_manufacturers
+      const mSeries: {x: string, y: number}[] = []
+      const pSeries: {x: string, y: number}[] = []
+      for (let index = 0; index < issuesByM.length; index++) {
+        const issue = issuesByM[index];
+        mSeries.push({x: issue.manufacturer, y: issue.myocarditis_count})
+        pSeries.push({x: issue.manufacturer, y: issue.pericarditis_count})
+      }
+      myocarditisSeries.value = mSeries
+      pericarditisSeries.value = pSeries
+      
+      carditisAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.ages_count
+      carditisUnkownAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.unknown_ages_count
+      carditisSummaryByAges.value = ConvertCarditisIssuesByAgesTo2dData(carditisSummaryData.value.carditis_issues.issues_by_ages.issues)
       
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -18,7 +18,7 @@
     <v-container v-else>
       <CustomHeader1 title="心筋炎/心膜炎 報告"></CustomHeader1>
       <p class="text-body-1 mb-2">
-        「新型コロナワクチン接種後の心筋炎又は心膜炎疑い」として製造販売業者から報告された <span class="big-bold">{{ carditisSummaryData?.carditis_summary.total.toLocaleString() }}</span> [件] の集計結果を示します。
+        「新型コロナワクチン接種後の心筋炎又は心膜炎疑い」として製造販売業者から報告された <span class="big-bold">{{ carditisSummaryData?.carditis_summary.total.toLocaleString() }}</span> 件の集計結果を示します。
       </p>
 
       <div class="d-flex justify-end">
@@ -54,20 +54,20 @@
 
       <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
       <div class="text-body-1">
-        心筋炎の報告 {{ carditisSummaryData.carditis_summary.myocarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
+        心筋炎の報告 <span class="big-bold">{{ carditisSummaryData.carditis_summary.myocarditis.toLocaleString() }}</span> 件を製造販売業者ごとに集計した結果です。
       </div>
       <HorizontalBarGraph :graph-title="['心筋炎の報告件数（製造販売業者別）']"
           x-axis-title="報告件数" download-file-name="myocarditis-count-by-manufacturer" :series="myocarditisSeries"></HorizontalBarGraph>
 
       <div class="text-body-1 mt-2">
-        心膜炎の報告 {{ carditisSummaryData.carditis_summary.pericarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
+        心膜炎の報告 <span class="big-bold">{{ carditisSummaryData.carditis_summary.pericarditis.toLocaleString() }}</span> 件を製造販売業者ごとに集計した結果です。
       </div>
       <HorizontalBarGraph :graph-title="['心膜炎の報告件数（製造販売業者別）']"
           x-axis-title="報告件数" download-file-name="pericarditis-count-by-manufacturer" :series="pericarditisSeries"></HorizontalBarGraph>
 
       <CustomHeader2 title="年代別の集計"></CustomHeader2>
       <div class="text-body-1 mb-5">
-        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ carditisAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ carditisUnknownAgesCount.toLocaleString() }} 件は年代不明）
+        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している <span class="big-bold">{{ carditisAgesCount.toLocaleString() }}</span> 件を年代ごとに集計した結果です。（{{ carditisUnknownAgesCount.toLocaleString() }} 件は年代不明）
       </div>
       <CarditisPerAgeGraph :series="carditisSummaryByAges"></CarditisPerAgeGraph>
       <p class="text-caption text-right mt-1">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」が発表した資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
@@ -85,7 +85,7 @@
 
     <v-container v-else>
       <CustomHeader1 title="亡くなられた方々に関する報告"></CustomHeader1>
-      <p class="text-body-1 mb-3">
+      <p class="text-body-1 mb-5">
         「新型コロナワクチン接種後の死亡例」として製造販売業者から報告された事例 <span class="big-bold">{{ deathSummaryData?.death_summary.sum_by_evaluation.total.toLocaleString() }}</span> [件] の集計結果を示します。
       </p>
 
@@ -133,7 +133,7 @@
 
       <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
       <div class="text-body-1 mt-2">
-        専門家による因果関係評価がβとγの報告 <span class="big-bold">{{ (deathSummaryData?.death_summary.sum_by_evaluation.beta + deathSummaryData?.death_summary.sum_by_evaluation.gamma).toLocaleString() }}</span> [件] を製造販売業者ごとに集計した結果です。
+        専門家による因果関係評価がαとγの報告 <span class="big-bold">{{ (deathSummaryData?.death_summary.sum_by_evaluation.alpha + deathSummaryData?.death_summary.sum_by_evaluation.gamma).toLocaleString() }}</span> 件を製造販売業者ごとに集計した結果です。
       </div>
       <HorizontalBarGraph :graph-title="['死亡報告の件数（製造販売業者別）']"
           x-axis-title="報告件数" download-file-name="death-count-by-manufacturer" :series="deathSummaryByManufacturer"></HorizontalBarGraph>
@@ -152,7 +152,7 @@
     <v-container v-else>
       <CustomHeader2 title="年代別の集計"></CustomHeader2>
       <div class="text-body-1 mb-5">
-        亡くなられた方々に関する報告 {{ (deathAgesCount + deathUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ deathAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ deathUnknownAgesCount.toLocaleString() }} 件は年代不明）
+        専門家による因果関係評価がαとγの報告 {{ (deathAgesCount + deathUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している <span class="big-bold">{{ deathAgesCount.toLocaleString() }}</span> 件を年代ごとに集計した結果です。（{{ deathUnknownAgesCount.toLocaleString() }} 件は年代不明）
       </div>
       <v-row>
         <v-col cols="12">
@@ -207,15 +207,20 @@ onMounted(() => {
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.myocarditis)
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.pericarditis)
 
-      const issuesByM = carditisSummaryData.value.carditis_issues.issues_by_manufacturers
+      const issuesMByM = carditisSummaryData.value.carditis_issues.issues_m_by_manufacturers
       const mSeries: {x: string, y: number}[] = []
-      const pSeries: {x: string, y: number}[] = []
-      for (let index = 0; index < issuesByM.length; index++) {
-        const issue = issuesByM[index];
-        mSeries.push({x: issue.manufacturer, y: issue.myocarditis_count})
-        pSeries.push({x: issue.manufacturer, y: issue.pericarditis_count})
+      for (let index = 0; index < issuesMByM.length; index++) {
+        const issueM = issuesMByM[index];
+        mSeries.push({x: issueM.manufacturer, y: issueM.count})
       }
       myocarditisSeries.value = mSeries
+
+      const issuesPByM = carditisSummaryData.value.carditis_issues.issues_p_by_manufacturers
+      const pSeries: {x: string, y: number}[] = []
+      for (let index = 0; index < issuesPByM.length; index++) {
+        const issueP = issuesMByM[index];
+        pSeries.push({x: issueP.manufacturer, y: issueP.count})
+      }
       pericarditisSeries.value = pSeries
       
       carditisAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.ages_count

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -66,8 +66,8 @@
           x-axis-title="報告件数" download-file-name="pericarditis-count-by-manufacturer" :series="pericarditisSeries"></HorizontalBarGraph>
 
       <CustomHeader2 title="年代別の集計"></CustomHeader2>
-      <div class="text-body-1 mb-2">
-        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnkownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ carditisAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ carditisUnkownAgesCount.toLocaleString() }} 件は年代不明）
+      <div class="text-body-1 mb-5">
+        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ carditisAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ carditisUnknownAgesCount.toLocaleString() }} 件は年代不明）
       </div>
       <CarditisPerAgeGraph :series="carditisSummaryByAges"></CarditisPerAgeGraph>
       <p class="text-caption text-right mt-1">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」が発表した資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
@@ -151,6 +151,9 @@
 
     <v-container v-else>
       <CustomHeader2 title="年代別の集計"></CustomHeader2>
+      <div class="text-body-1 mb-5">
+        亡くなられた方々に関する報告 {{ (deathAgesCount + deathUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ deathAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ deathUnknownAgesCount.toLocaleString() }} 件は年代不明）
+      </div>
       <v-row>
         <v-col cols="12">
           <DeathPerAgeGraph :series="deathSummaryDataFromReports.death_summary_from_reports.sum_by_age"></DeathPerAgeGraph>
@@ -169,7 +172,7 @@ import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
-import { ConvertCarditisIssuesByAgesTo2dData, type ICarditisSummaryRoot } from '@/types/CarditisSummary'
+import { type ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
@@ -189,10 +192,12 @@ const myocarditisSeries = shallowRef<{x: string, y: number}[]>([])
 const pericarditisSeries = shallowRef<{x: string, y: number}[]>([])
 const carditisSummaryByAges = shallowRef<{x:string, y:number}[]>([])
 const carditisAgesCount = shallowRef<number>(0)
-const carditisUnkownAgesCount = shallowRef<number>(0)
+const carditisUnknownAgesCount = shallowRef<number>(0)
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()
 const deathSummaryByManufacturer = shallowRef<{x:string, y:number}[]>([])
 const deathSummaryDataFromReports = shallowRef<IDeathSummaryFromReportsRoot>()
+const deathAgesCount = shallowRef<number>(0)
+const deathUnknownAgesCount = shallowRef<number>(0)
 onMounted(() => {
   axios
     .get<ICarditisSummaryRoot>(CarditisSummaryURL)
@@ -214,8 +219,8 @@ onMounted(() => {
       pericarditisSeries.value = pSeries
       
       carditisAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.ages_count
-      carditisUnkownAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.unknown_ages_count
-      carditisSummaryByAges.value = ConvertCarditisIssuesByAgesTo2dData(carditisSummaryData.value.carditis_issues.issues_by_ages.issues)
+      carditisUnknownAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.unknown_ages_count
+      carditisSummaryByAges.value = carditisSummaryData.value.carditis_issues.issues_by_ages.issues
       
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -251,6 +256,8 @@ onMounted(() => {
     .get<IDeathSummaryFromReportsRoot>(DeathSummaryFromReportsURL)
     .then((response) => {
       deathSummaryDataFromReports.value = response.data
+      deathAgesCount.value = response.data.death_summary_from_reports.ages_count
+      deathUnknownAgesCount.value = response.data.death_summary_from_reports.unknown_ages_count
 
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -133,7 +133,7 @@
 
       <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
       <div class="text-body-1 mt-2">
-        専門家による因果関係評価がβとγの報告 {{ (deathSummaryData?.death_summary.sum_by_evaluation.beta + deathSummaryData?.death_summary.sum_by_evaluation.gamma).toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
+        専門家による因果関係評価がβとγの報告 <span class="big-bold">{{ (deathSummaryData?.death_summary.sum_by_evaluation.beta + deathSummaryData?.death_summary.sum_by_evaluation.gamma).toLocaleString() }}</span> [件] を製造販売業者ごとに集計した結果です。
       </div>
       <HorizontalBarGraph :graph-title="['死亡報告の件数（製造販売業者別）']"
           x-axis-title="報告件数" download-file-name="death-count-by-manufacturer" :series="deathSummaryByManufacturer"></HorizontalBarGraph>
@@ -202,16 +202,6 @@ onMounted(() => {
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.myocarditis)
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.pericarditis)
 
-      for (let index = 0; index < carditisSummaryData.value.carditis_issues.issues_with_vaccine_name.length; index++) {
-        const issue = carditisSummaryData.value.carditis_issues.issues_with_vaccine_name[index]
-
-        myocarditisByVaccineLabels.value.push(issue.vaccine_name)
-        myocarditisByVaccineSeries.value.push(issue.myocarditis_count)
-
-        pericarditisByVaccineLabels.value.push(issue.vaccine_name)
-        pericarditisByVaccineSeries.value.push(issue.pericarditis_count)
-      }
-
       const issuesByM = carditisSummaryData.value.carditis_issues.issues_by_manufacturers
       const mSeries: {x: string, y: number}[] = []
       const pSeries: {x: string, y: number}[] = []
@@ -243,12 +233,6 @@ onMounted(() => {
       deathSummarySeries.value.push(deathSummaryData.value.death_summary.sum_by_evaluation.beta)
       deathSummaryLabels.value.push('γ')
       deathSummarySeries.value.push(deathSummaryData.value.death_summary.sum_by_evaluation.gamma)
-
-      for (let index = 0; index < deathSummaryData.value.death_summary.sum_by_vaccine_name.length; index++) {
-        const element = deathSummaryData.value.death_summary.sum_by_vaccine_name[index];
-        deathSummaryByVaccineLabels.value.push(element.vaccine_name)
-        deathSummaryByVaccineSeries.value.push(element.evaluations.alpha + element.evaluations.gamma)
-      }
 
       const sum_by_manufacturer = deathSummaryData.value.death_summary.sum_by_manufacturer
       const seriesManufacturer: {x:string, y:number}[] = []
@@ -324,116 +308,6 @@ const carditisSummaryOptions = {
   }
 }
 
-const myocarditisByVaccineLabels = shallowRef<string[]>([])
-const myocarditisByVaccineSeries = shallowRef<any[]>([])
-const myocarditisByVaccineOptions = {
-  title: {
-    text: 'ワクチン種類ごとの心筋炎件数',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: myocarditisByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(1) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
-const pericarditisByVaccineLabels = shallowRef<string[]>([])
-const pericarditisByVaccineSeries = shallowRef<any[]>([])
-const pericarditisByVaccineOptions = {
-  title: {
-    text: 'ワクチン種類ごとの心膜炎件数',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: pericarditisByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(1) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
 const deathSummaryLabels = shallowRef<string[]>([])
 const deathSummarySeries = shallowRef<any[]>([])
 const deathSummaryOptions = {
@@ -443,9 +317,11 @@ const deathSummaryOptions = {
     offsetX: 10,
     offsetY: 10,
   },
-  chart: { type: 'pie' },
+  chart: { 
+    type: 'pie',
+  },
   legend: {
-    position: 'bottom',
+    position: 'right',
   },
   labels: deathSummaryLabels.value,
   plotOptions: {
@@ -489,78 +365,9 @@ const deathSummaryOptions = {
   }
 }
 
-const deathSummaryByVaccineLabels = shallowRef<string[]>([])
-const deathSummaryByVaccineSeries = shallowRef<any[]>([])
-const deathSummaryByVaccineOptions = {
-  title: {
-    text: 'α・γ評価のワクチン別 内訳',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: deathSummaryByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(2) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
 const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
-}
-
-const addNewLineWithBrackets = (label: string): string => {
-  label = label.replace('（','(')
-  label = label.replace('）',')')
-  
-  let split = label.split('(')
-  if(split.length < 2) return label
-
-  let joined = split[0] + '\r\n'
-  for (let index = 1; index < split.length; index++) {
-    joined += '(' + split[index];
-  }
-  return joined
 }
 </script>
 


### PR DESCRIPTION
Issue #55 の問題を解決するため、何回かにわたり`datasets`側も修正を行った。
本プルリクは、それら新しいデータを用いて [製造販売業者からの報告 - 集計結果 ページ](https://vaccinesosjapan.github.io/dashboard/#/suspected-issues-summary) を修正するもの。

## 主な変更点

* 心筋炎/心膜炎
  * ワクチンの種類ごとの集計を削除し、「製造販売業者別の集計」「年代別の集計」を追加
* 亡くなった方々
  * ワクチンの種類ごとの集計を削除し、「製造販売業者別の集計」を追加

また、各グラフの母数（どれだけの件数のデータに対して集計したグラフなのか）を説明文で明記するように修正した。

![image](https://github.com/user-attachments/assets/781940a4-d827-46fd-8d1d-d2a956932500)

Close #55