### PR TITLE
fix: 参考情報ページのトゲトゲアイコンをレスポンシブにサイズ調整できるよう修正

### DIFF
--- a/src/components/CustomWarningIcon.vue
+++ b/src/components/CustomWarningIcon.vue
@@ -1,0 +1,18 @@
+<template>
+    <v-icon class="d-block d-sm-none d-md-none" icon="mdi-alert-decagram-outline" :size="sizeArray[0]" color="warning"></v-icon>
+    <v-icon class="d-none d-sm-block d-md-none" icon="mdi-alert-decagram-outline" :size="sizeArray[1]" color="warning"></v-icon>
+    <v-icon class="d-none d-sm-none d-md-block" icon="mdi-alert-decagram-outline" :size="sizeArray[2]" color="warning"></v-icon>
+</template>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue';
+
+const props = defineProps<{
+  size: string
+}>()
+
+const sizeArray = shallowRef<number[]>([35, 50, 65])
+if (props.size.toLowerCase() == 'large'){
+    sizeArray.value = [45, 60, 75]
+}
+</script>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -3,6 +3,7 @@ import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from 
 import router from '@/router/index'
 import CustomHeader1 from '@/components/CustomHeader1.vue'
 import CustomHeader2 from '@/components/CustomHeader2.vue'
+import CustomWarningIcon from '@/components/CustomWarningIcon.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-grey-lighten-4'
@@ -42,18 +43,18 @@ AppBarHelpPageLink.value = ''
         <v-card-text class="text-body-1">
           <v-row>
             <v-col cols="1">
-              <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
+              <CustomWarningIcon size="large" />
             </v-col>
             <v-col cols="11">
               <ul class="pl-10 mt-2">
-                <li class="text-body-1 yuttari">
+                <li class="text-body-1">
                 本サイトのグラフや表など「データを可視化したコンテンツ」を、SNSで引用するなど多くの人に共有する使い方をする場合、本ダッシュボードのURLと共に
                 共有してください。
                 </li>
-                <li class="text-body-1 yuttari mt-2">
+                <li class="text-body-1 mt-2">
                 引用したコンテンツならびに加工したコンテンツを、「自分が作った」と偽る行為を禁じます。
                 </li>
-                <li class="text-body-1 yuttari mt-2">
+                <li class="text-body-1 mt-2">
                 講演会での利用や著作物への引用など<span class="big-bold">営利目的で利用する場合</span>の、<span class="big-bold">無断使用を禁じます。</span>
                 必ず事前に所有者に許可を得てください。
                 </li>
@@ -74,14 +75,11 @@ AppBarHelpPageLink.value = ''
 .big-bold {
   font-size: 1.4rem;
   font-weight: bolder;
+  line-height: 1.5;
 }
 
 .wave-under-bar{
   text-decoration: underline;
   text-underline-offset: 4px;
-}
-
-.yuttari {
-  line-height: 1.8rem;
 }
 </style>

--- a/src/views/MedicalInstitutionReferenceView.vue
+++ b/src/views/MedicalInstitutionReferenceView.vue
@@ -16,9 +16,9 @@
         <v-card-text class="text-body-1">
           <v-row>
             <v-col cols="1">
-              <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
+              <CustomWarningIcon size="medium" />
             </v-col>
-            <v-col cols="11">
+            <v-col cols="11" class="pl-7">
               <p class="text-body-1">
                 このページの内容は、膨大な副反応疑い報告から考察・調査を行う糸口を掴んでいただく一助となることを意図しております。
               </p>
@@ -93,6 +93,7 @@ import type { ILotNumberItem } from '@/types/LotNumberInfomation'
 import CustomHeader1 from '@/components/CustomHeader1.vue'
 import CustomHeader2 from '@/components/CustomHeader2.vue'
 import HorizontalBarGraph from '@/components/HorizontalBarGraph.vue'
+import CustomWarningIcon from '@/components/CustomWarningIcon.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-accent-1'
@@ -148,5 +149,6 @@ const createUrl = (value: string) => {
 .wave-under-bar{
   text-decoration: underline;
   text-underline-offset: 4px;
+  line-height: 1.5;
 }
 </style>

--- a/src/views/SuspectedIssuesReferenceView.vue
+++ b/src/views/SuspectedIssuesReferenceView.vue
@@ -16,9 +16,9 @@
         <v-card-text class="text-body-1">
           <v-row>
             <v-col cols="1">
-              <v-icon icon="mdi-alert-decagram-outline" size="70" color="warning"></v-icon>
+              <CustomWarningIcon size="medium" />
             </v-col>
-            <v-col cols="11">
+            <v-col cols="11" class="pl-7">
               <p class="text-body-1">
                 このページの内容は、膨大な心筋炎/心膜炎報告や亡くなった方々の報告（いずれも製造販売業者からの副反応疑い報告が母集団）から考察・調査を行う糸口を掴んでいただく一助となることを意図しております。
               </p>
@@ -135,6 +135,7 @@ import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromRepor
 import CustomHeader1 from '@/components/CustomHeader1.vue'
 import CustomHeader2 from '@/components/CustomHeader2.vue'
 import HorizontalBarGraph from '@/components/HorizontalBarGraph.vue'
+import CustomWarningIcon from '@/components/CustomWarningIcon.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-accent-1'
@@ -227,5 +228,6 @@ const createUrlForDeath = (value: string) => {
 .wave-under-bar{
   text-decoration: underline;
   text-underline-offset: 4px;
+  line-height: 1.5;
 }
 </style>


### PR DESCRIPTION
横幅が限られた画面でも、トゲトゲアイコンが文字に被らないように調整した。

![image](https://github.com/user-attachments/assets/fe01c4ac-e01e-4530-a944-b1a91176cead)

![image](https://github.com/user-attachments/assets/6f93bc30-8f91-46d2-8fa3-12b689c05014)

Close #59
