### PR TITLE
fix: X軸用と日付選択用でソート順が異なるので別の配列にする

### DIFF
--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -88,7 +88,7 @@ for (let index = 0; index < props.data.length; index++) {
 }
 
 // 日付選択用に、日付が新しい方から古い方へと並び替える
-const datesForSelection = xAxisLabels.value.sort((one, two) => (one > two ? -1 : 1))
+const datesForSelection = xAxisLabels.value.concat().sort((one, two) => (one > two ? -1 : 1))
 
 // Seriesデータを作成
 const eachCountAndRateSeries = shallowRef<ISeriesValue[]>([])


### PR DESCRIPTION
「X軸用のデータ」に使用している配列を複製してから、降順にソートして「日付選択用のデータ」に使うよう修正。

Close #71 