### PR TITLE
Improve header style

### DIFF
--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -57,6 +57,7 @@
 import type { IJudgedData, IJudgedDataGraphInfo } from '@/types/JudgedData';
 import { shallowRef } from 'vue';
 import SelectDateToOpenIssues from '@/components/SelectDateToOpenIssues.vue'
+import { CertifiedColors } from '@/tools/BarColors';
 
 const props = defineProps<{
   data: IJudgedData[]
@@ -178,8 +179,8 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
     title: {
       text: info.GraphTitle,
       style: {
-        fontSize: '1.2rem',
-        colors: ['#212121'],
+        fontSize: '1.4rem',
+        color: '#212121',
       },
       offsetY: 20
     },
@@ -202,7 +203,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
         offsetY: -25,
         style: {
           fontSize: '1rem',
-          colors: ['#212121'],
+          color: '#212121',
         },
       }
     },
@@ -214,7 +215,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
             return value.toLocaleString()
           },
           style: {
-            colors: ['#E83938'],
+            colors: [CertifiedColors.Denied],
           }
         },
         max: info.CountYAxisMax
@@ -225,7 +226,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
           text: info.CountTitle,
           style: {
             fontSize: '1rem',
-            color: '#6CAF52',
+            color: CertifiedColors.Certified,
           },
         },
         labels: {
@@ -233,7 +234,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
             return value.toLocaleString()
           },
           style: {
-            colors: ['#6CAF52'],
+            colors: [CertifiedColors.Certified],
           }
         },
         max: info.CountYAxisMax,
@@ -245,7 +246,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
           text: info.RateTitle,
           style: {
             fontSize: '1rem',
-            color: '#7560CF',
+            color: CertifiedColors.CertifiedRate,
           },
         },
         min: 0,
@@ -255,12 +256,12 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
             return value.toFixed(1)
           },
           style: {
-            colors: ['#7560CF'],
+            colors: [CertifiedColors.CertifiedRate],
           }
         },
       }
     ],
-    colors: ['#E83938', '#6CAF52', '#7560CF'],
+    colors: [CertifiedColors.Denied, CertifiedColors.Certified, CertifiedColors.CertifiedRate],
     legend: {
       fontSize: '14',
     }

--- a/src/components/CustomHeader1.vue
+++ b/src/components/CustomHeader1.vue
@@ -1,10 +1,10 @@
 /* 
   md以上: h4サイズ
-  md以下: h5かつ下線
+  md以下: h5サイズ
 */
 <template>
-	<h1 class="d-none d-md-flex text-h4 mb-2">{{ title }}</h1>
-  <h1 class="d-flex d-md-none text-h5 underline mb-2">{{ title }}</h1>
+	<h1 class="d-none d-md-flex text-h4 justify-center mb-2">{{ title }}</h1>
+  <h1 class="d-flex d-md-none text-h5 justify-center mb-2">{{ title }}</h1>
 </template>
 
 <script setup lang="ts">
@@ -14,10 +14,10 @@ defineProps<{
 </script>
 
 <style scoped>
-.underline{
-  text-underline-offset: 0.25rem;
-  text-decoration-line: underline;
-  text-decoration-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
-  text-decoration-thickness: 1.5px;
+h1 {
+  background-color: #4CAF50;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 15px;
 }
 </style>

--- a/src/components/JudgedSplitDataBar.vue
+++ b/src/components/JudgedSplitDataBar.vue
@@ -1,0 +1,185 @@
+<template>
+  <apexchart :options="chartOption" :series="series"></apexchart>
+</template>
+
+<script setup lang="ts">
+import { CertifiedColors, CertifiedColorsByClaimType } from '@/tools/BarColors';
+import { type IJudgedSplitData } from '@/types/JudgedSplitData';
+import { shallowRef } from 'vue';
+
+const props = defineProps<{
+  x_axis_data: string[]
+  data: IJudgedSplitData
+}>()
+
+const chartOption = shallowRef<any>()
+//const graphTitle = props.data.cumulative ? `累計の認定件数の推移 - ${props.data.display_name}` : `審議会ごとの認定件数の推移 - ${props.data.display_name}`
+const graphTitle = `【${props.data.display_name}】認定比率・審査数 累計`
+const barColor = SelectBarColor(props.data.id)
+chartOption.value = CreateCountAndRateChartOption(graphTitle, props.x_axis_data, barColor, props.data.sum_y_axis_max, props.data.id)
+const series = shallowRef<any>()
+series.value = [
+	{
+		name: '認定比率',
+		type: 'line',
+		data: props.data.certified_rate_sum
+	},
+	{
+		name: '否認',
+		type: 'bar',
+		data: props.data.denied_sum_data
+	},
+	{
+		name: '認定',
+		type: 'bar',
+		data: props.data.certified_sum_data
+	},
+]
+</script>
+
+<script lang="ts">
+const xAxisTitle = '審議会の開催日'
+
+const SelectBarColor = (claimType: string): string => {
+  if (claimType.startsWith('medical')) {
+    return CertifiedColorsByClaimType.Medical
+  } else if (claimType.startsWith('disability_of_children')) {
+    return CertifiedColorsByClaimType.DisabilityOfChildren
+  } else if (claimType.startsWith('disability')) {
+    return CertifiedColorsByClaimType.Disability
+  } else if (claimType.startsWith('death')) {
+    return CertifiedColorsByClaimType.Death
+  } else {
+    return CertifiedColorsByClaimType.Medical
+  }
+}
+
+const CreateCountAndRateChartOption = (title: string, labels: string[], color: string, yMax: number, downloadFileName: string): any =>{
+  return {
+    chart: {
+      type: 'line',
+      stacked: true,
+      toolbar: {
+        export: {
+          csv: {
+            headerCategory: xAxisTitle,
+            headerValue: 'value',
+            categoryFormatter(x: any) {
+              return new Date(x).toDateString()
+            },
+						filename: downloadFileName,
+          },
+          svg: {
+						filename: downloadFileName,
+					},
+					png: {
+						filename: downloadFileName,
+					}
+        }
+      }
+    },
+    stroke: {
+      width: 5,
+      //curve: 'stepline',
+    },
+    title: {
+      text: title,
+      style: {
+        fontSize: '1.4rem',
+        color: color,
+      },
+      offsetY: 20
+    },
+    tooltip: {
+      y: {
+        formatter: function(value: any, { series, seriesIndex, dataPointIndex, w } :any) {
+          if(w.config.series[seriesIndex].name == '認定比率'){
+            return (value as number).toFixed(1) + ' %'
+          } else {
+            return (value as number).toLocaleString() + ' 件'
+          }
+        }
+      },
+    },
+    xaxis: {
+      categories: labels,
+      type: 'category',
+      title: {
+        text: xAxisTitle,
+        offsetY: -25,
+        style: {
+          fontSize: '1rem',
+          colors: ['#212121'],
+        },
+      }
+    },
+    yaxis: [
+      {
+        seriesName: "認定比率",
+        opposite: false,
+        title: {
+          text: "認定比率 [%]",
+          style: {
+            fontSize: '1rem',
+            color: CertifiedColors.CertifiedRate,
+          },
+        },
+        min: 0,
+        max: 100.0,
+        labels: {
+          formatter: function (value: any) {
+            return value.toFixed(1)
+          },
+          style: {
+            colors: [CertifiedColors.CertifiedRate],
+          }
+        },
+      },
+      {
+        seriesName: ['認定', '否認'],
+        opposite: true,
+        labels: {
+          formatter: function (value: any) {
+            return value.toLocaleString()
+          },
+          style: {
+            colors: [CertifiedColors.Denied],
+          }
+        },
+        max: yMax
+      },
+      {
+        seriesName: ['認定', '否認'],
+        opposite: true,
+        title: {
+          text: '件数 [件]',
+          style: {
+            fontSize: '1rem',
+            color: CertifiedColors.Certified,
+          },
+        },
+        labels: {
+          formatter: function (value: any) {
+            return value.toLocaleString()
+          },
+          style: {
+            colors: [CertifiedColors.Certified],
+          }
+        },
+        max: yMax,
+      },
+    ],
+    dataLabels: {
+      enabled: false,
+    },
+    colors: [ CertifiedColors.CertifiedRate, CertifiedColors.Denied, CertifiedColors.Certified ],
+    legend: {
+      fontSize: '14',
+      offsetX: -80,
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -35,6 +35,8 @@ export const CertifiedSymptomsDataURL = DatasetsURL + 'certified-symptoms.json'
 export const CertifiedSymptomsMetadataURL = DatasetsURL + 'certified-symptoms-metadata.json'
 
 export const JudgedDataURL = DatasetsURL + 'judged-data.json'
+export const JudgedSplitDataURL = DatasetsURL + 'judged-split-data.json'
 export const JudgedDataEachGraphSmallImageURL = DatasetsURL + 'images/each-result-of-judged-count.svg'
 export const JudgedDataAllGraphSmallImageURL = DatasetsURL + 'images/all-result-of-judged-count.svg'
 export const CertifiedSummaryWithOtherVaccinesThumbnailURL = DatasetsURL + 'images/certified-summary-with-other-vaccines.svg'
+export const JudgedSplitAltImageBaseURL = DatasetsURL + 'images/certified-data/'

--- a/src/tools/BarColors.ts
+++ b/src/tools/BarColors.ts
@@ -1,0 +1,12 @@
+export const CertifiedColorsByClaimType = {
+	Medical: '#3393FA',
+	DisabilityOfChildren: '#54E496',
+	Disability: '#F6AD21',
+	Death: '#F23B61',
+} as const
+
+export const CertifiedColors = {
+	Certified: '#6CAF52',
+	Denied: '#E83938',
+	CertifiedRate: '#7560CF',
+} as const

--- a/src/types/JudgedData.ts
+++ b/src/types/JudgedData.ts
@@ -1,12 +1,12 @@
 // 審査結果の毎回の件数や累計の件数、認定の割合などのデータ
 export interface IJudgedData {
 	Date: string
-    CertifiedCount: number
-    RepudiationCount: number,
-    CertifiedRate: number,
-    CertifiedCountSum: number,
-    RepudiationCountSum: number,
-    CertifiedRateSum: number
+  CertifiedCount: number
+  RepudiationCount: number
+  CertifiedRate: number
+  CertifiedCountSum: number
+  RepudiationCountSum: number
+  CertifiedRateSum: number
 }
 
 // 審査結果の件数や認定割合をグラフ化する時の情報（Y軸タイトルなど）

--- a/src/types/JudgedSplitData.ts
+++ b/src/types/JudgedSplitData.ts
@@ -1,0 +1,19 @@
+// 審議会のデータを請求内容ごとに集計したデータ。
+// 審議会の日付データ（x_axis_data）は全てのデータで共通のため、1つだけ保持する。
+export interface IJudgedSplitDataList {
+	x_axis_data: string[]
+	data_list: IJudgedSplitData[]
+}
+
+export interface IJudgedSplitData {
+	id: string
+	display_name: string
+	certified_data: number[]
+	certified_sum_data: number[]
+	denied_data: number[]
+	denied_sum_data: number[]
+	certified_rate: number[]
+	certified_rate_sum: number[]
+	normal_y_axis_max: number
+	sum_y_axis_max: number
+}


### PR DESCRIPTION
「請求内容ごとの傾向」などの見出し1全てに、「緑色の角丸四角で囲む」「中央寄せの白文字で描画」というスタイルを適用する変更。

PC画面での雰囲気
<img width="1115" height="735" alt="image" src="https://github.com/user-attachments/assets/a48ace28-797a-4f13-9b33-5ae67774c0a3" />

スマホ画面での雰囲気
<img width="473" height="683" alt="image" src="https://github.com/user-attachments/assets/a5628605-b3fa-4c07-87ef-75148a40ff37" />
