### PR TITLE
Add split each graph for judged issues

### DIFF
--- a/src/components/JudgedSplitDataBar.vue
+++ b/src/components/JudgedSplitDataBar.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
 }>()
 
 const chartOption = shallowRef<any>()
-//const graphTitle = props.data.cumulative ? `累計の認定件数の推移 - ${props.data.display_name}` : `審議会ごとの認定件数の推移 - ${props.data.display_name}`
+//const graphTitle = props.data.cumulative ? `累計の認定件数の推移 - ${props.data.display_name}` : `審査会ごとの認定件数の推移 - ${props.data.display_name}`
 const graphTitle = `【${props.data.display_name}】認定比率・審査数 累計`
 const barColor = SelectBarColor(props.data.id)
 chartOption.value = CreateCountAndRateChartOption(graphTitle, props.x_axis_data, barColor, props.data.sum_y_axis_max, props.data.id)

--- a/src/components/SelectDateToOpenIssues.vue
+++ b/src/components/SelectDateToOpenIssues.vue
@@ -16,7 +16,7 @@
 			</v-select>
 		</v-col>
 		<v-col cols="12" md="4" sm="5">
-			<v-btn @click="openIssues">審議会データを確認する</v-btn>
+			<v-btn @click="openIssues">審査会データを確認する</v-btn>
 		</v-col>
 	</v-row>
 
@@ -35,12 +35,12 @@
 					></v-text-field>
 				</template>
 			</v-select>
-			<v-btn @click="openIssues" class="mt-1">審議会データを確認する</v-btn>
+			<v-btn @click="openIssues" class="mt-1">審査会データを確認する</v-btn>
 		</v-col>
 	</v-row>
 
 	<v-snackbar v-model="snackbarActivator" :timeout="timeout" color="warning">
-      データを表示したい審議会の日付を選択してください。
+      データを表示したい審査会の日付を選択してください。
     </v-snackbar>
 </template>
 

--- a/src/tools/BarColors.ts
+++ b/src/tools/BarColors.ts
@@ -10,3 +10,17 @@ export const CertifiedColors = {
 	Denied: '#E83938',
 	CertifiedRate: '#7560CF',
 } as const
+
+export const SelectBarColorById = (id: string): string => {
+  if (id.startsWith('medical')) {
+    return CertifiedColorsByClaimType.Medical
+  } else if (id.startsWith('disability_of_children')) {
+    return CertifiedColorsByClaimType.DisabilityOfChildren
+  } else if (id.startsWith('disability')) {
+    return CertifiedColorsByClaimType.Disability
+  } else if (id.startsWith('death')) {
+    return CertifiedColorsByClaimType.Death
+  } else {
+    return CertifiedColorsByClaimType.Medical
+  }
+}

--- a/src/types/JudgedSplitData.ts
+++ b/src/types/JudgedSplitData.ts
@@ -1,5 +1,5 @@
-// 審議会のデータを請求内容ごとに集計したデータ。
-// 審議会の日付データ（x_axis_data）は全てのデータで共通のため、1つだけ保持する。
+// 審査会のデータを請求内容ごとに集計したデータ。
+// 審査会の日付データ（x_axis_data）は全てのデータで共通のため、1つだけ保持する。
 export interface IJudgedSplitDataList {
 	x_axis_data: string[]
 	data_list: IJudgedSplitData[]

--- a/src/views/CertifiedHealthHazardsHomeView.vue
+++ b/src/views/CertifiedHealthHazardsHomeView.vue
@@ -75,8 +75,8 @@
       ></v-progress-circular>
     </v-container>
     <v-container v-else>
-      <CustomHeader1 title="審議会の傾向" :bg_color="headerColor" />
-      <p class="text-body-1 mb-2">各審議会での件数および認定比率や、全審議会における累計の件数および認定比率は以下の通りです。</p>
+      <CustomHeader1 title="審査会の傾向" :bg_color="headerColor" />
+      <p class="text-body-1 mb-2">各審査会での認定比率・審査数や、全審査会における累計の認定比率・審査数をグラフ化したものを以下に示します。</p>
 
       <CountAndRateGraph :data="judgedDataArray"
       :each-info="eachCountAndRateGraphInfo" :each-alt-image-path="JudgedDataEachGraphSmallImageURL"
@@ -96,7 +96,7 @@
     </v-container>
     <v-container v-else>
       <CustomHeader1 title="請求内容ごとの傾向" :bg_color="headerColor" />
-      <p class="text-body-1 mb-2">認定された症例を「請求内容」ごとに集計し、認定比率と累計の審査数とをグラフ化したものを以下に示します。</p>
+      <p class="text-body-1 mb-2">「請求内容」ごとに集計し、各審査会での認定比率・審査数や、全審査会における累計の認定比率・審査数をグラフ化したものを以下に示します。</p>
 
       <v-row class="d-none d-md-flex mt-3">
         <v-col cols="12" v-for="data in judgedSplitDataList.data_list" :key="data.id">
@@ -342,7 +342,7 @@ onMounted(() => {
       CountYAxisMaxSum = Math.round( (CountYAxisMaxSum + 1000) / place ) * place;
 
       eachCountAndRateGraphInfo.value = {
-        GraphTitle: '各審議会における認定比率・審査数',
+        GraphTitle: '各審査会における認定比率・審査数',
         CountTitle: '審査数 [件]',
         RateTitle: '認定比率 [%]',
         RepudiationSeriesName: '否認件数',

--- a/src/views/CertifiedHealthHazardsHomeView.vue
+++ b/src/views/CertifiedHealthHazardsHomeView.vue
@@ -100,7 +100,8 @@
 
       <v-row class="d-none d-md-flex mt-3">
         <v-col cols="12" v-for="data in judgedSplitDataList.data_list" :key="data.id">
-          <JudgedSplitDataBar :x_axis_data="judgedSplitDataList.x_axis_data" :data="data" />
+          <JudgedSplitDataBar :x_axis_data="judgedSplitDataList.x_axis_data" :data="data" :cumulative="false" />
+          <JudgedSplitDataBar :x_axis_data="judgedSplitDataList.x_axis_data" :data="data" :cumulative="true" />
         </v-col>
       </v-row>
       
@@ -110,8 +111,10 @@
         </v-col>
 
         <v-col cols="12" v-for="data in judgedSplitDataList.data_list" :key="data.id">
-          <h3 class="small-h3">{{ `【${data.display_name}】認定比率・審査数 累計` }}</h3>
+          <h3 class="small-h3" :style="{color: SelectBarColorById(data.id)}">{{ `【${data.display_name}】認定比率・審査数 審査会ごと` }}</h3>
           <v-img :src="JudgedSplitAltImageBaseURL + data.id + '.svg'"></v-img>
+          <h3 class="small-h3" :style="{color: SelectBarColorById(data.id)}">{{ `【${data.display_name}】認定比率・審査数 累計` }}</h3>
+          <v-img :src="JudgedSplitAltImageBaseURL + data.id + '_cumulative.svg'"></v-img>
         </v-col>
       </v-row>
     </v-container>
@@ -209,6 +212,7 @@ import OtherVaccinesGraph from '@/components/OtherVaccinesGraph.vue'
 import ClaimChart from '@/components/ClaimChart.vue'
 import type { IJudgedSplitDataList } from '@/types/JudgedSplitData'
 import JudgedSplitDataBar from '@/components/JudgedSplitDataBar.vue'
+import { SelectBarColorById } from '@/tools/BarColors';
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'green'


### PR DESCRIPTION
区分別のグラフに関して、「審査会ごと」と「累計」の両方のグラフを掲載するように改善する。
また、「審査会」と書くべきところ「審議会」と誤って記載していた箇所があったので、あわせて修正した。

<img width="1271" height="902" alt="image" src="https://github.com/user-attachments/assets/eb1bc5ad-88f9-40c9-a323-8289d050369e" />

<img width="1276" height="784" alt="image" src="https://github.com/user-attachments/assets/181a3b79-dad4-4135-bbe8-32104e817420" />

